### PR TITLE
fix(tagsInput): pressing tab and selecting an autocomplete result throws...

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -213,6 +213,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, tiConfiguration) 
                         return;
                     }
                     scope.hasFocus = true;
+                    if(scope.$root.$$phase) {
+                        return;
+                    }
                     scope.$apply();
                 })
                 .on('blur', function() {


### PR DESCRIPTION
... digest error

If you manage to blur input while autocomplete is open and than click
an auto-complete result you get a digest in progress error.

Reproduce plunkr: http://plnkr.co/edit/4Gn77U?p=preview
Required environment:
ngTagsInput with the setting `add-on-blur="false"` and another input.

Reproduce steps:
- Write something to autocomplete and make it visible.
- Press tab button. The second inputs should get focus.
- Now click to an autocomplete result BY mouse. This triggers a focus
  event to input. Focus event to input calls `$scope.apply()` if not already focused.
  However in this flow it is not focuces. So, it tries to apply. However,
  It was already started on click.
- Check your console to see the error.

This fixed by checking digest status before calling `$apply`
