### PR TITLE
Update auto-complete.html

### DIFF
--- a/templates/auto-complete.html
+++ b/templates/auto-complete.html
@@ -1,7 +1,7 @@
 <div class="autocomplete" ng-show="suggestionList.visible"> 
   <ul class="suggestion-list">
     <li class="suggestion-item"
-        ng-repeat="item in suggestionList.items | limitTo:options.maxResultsToShow track by track(item)"
+        ng-repeat="item in suggestionList.items | limitTo:options.maxResultsToShow track by $index"
         ng-class="{selected: item == suggestionList.selected}"
         ng-click="addSuggestion()"
         ng-mouseenter="suggestionList.select($index)"


### PR DESCRIPTION
Fixed a bug when autocomplete was breaking if results had same name but different ids:

Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: item in suggestionList.items | limitTo:options.maxResultsToShow track by track(item.id), Duplicate key: undefined
