### PR TITLE
feat(tagsInput): Add addOnTab option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -128,6 +128,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 addOnSpace: [Boolean, false],
                 addOnComma: [Boolean, true],
                 addOnBlur: [Boolean, true],
+                addOnTab: [Boolean, true],
                 allowedTagsPattern: [RegExp, /.+/],
                 enableEditingLastTag: [Boolean, false],
                 minTags: [Number],
@@ -167,7 +168,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             };
         },
         link: function(scope, element, attrs, ngModelCtrl) {
-            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace],
+            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace, KEYS.tab],
                 tagList = scope.tagList,
                 events = scope.events,
                 options = scope.options,
@@ -248,7 +249,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     addKeys[KEYS.comma] = options.addOnComma;
                     addKeys[KEYS.space] = options.addOnSpace;
 
-                    shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
+                    shouldAdd = !options.addFromAutocompleteOnly && addKeys[key] && scope.newTag.text.length === 0;
                     shouldRemove = !shouldAdd && key === KEYS.backspace && scope.newTag.text.length === 0;
 
                     if (shouldAdd) {

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -57,6 +57,7 @@
     <tags-input name="tags" ng-init="tags2=['item1', 'item2', 'item3']" ng-model="tags2" display-property="label"
                 add-on-enter="{{addOnEnter}}"
                 add-on-blur="true"
+                add-on-tab="true"
                 placeholder="{{placeholder}}"
                 remove-tag-symbol="{{removeTagSymbol}}"
                 max-length="5"


### PR DESCRIPTION
Is this a feature ngTagsInput wants? 

This change causes 18 tests to break. But all the functionality still works in my app.

Let me know if the functionality is wanted, and I'll dig into why the current tests fail and write some tests for the new option of my own and fix this PR.

Cheers,
Dan
(PS never submitted a pull request to an OS project before, so lemme know if you have any tips on my "form" here.)

Commit Msg:

The option addOnTab defaults to false, which should maintain current
behavior. When addOnTab is true and you hit tab with no text entered,
addOnTab option advances to the next field (like normal html form).
When you hit tab with text entered, addOnTab option completes the tab
AND leaves you inside the current tagsInput

Basically make ngTagsInput like gmail emailTo address tags.
