### PR TITLE
Allow the autocomplete to have its own displayProperty

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -126,8 +126,9 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, tagsInpu
 
             suggestionList = new SuggestionList(scope.source, options);
 
+            var displayProperty = attrs.displayProperty || options.tagsInput.displayProperty;
             getItemText = function(item) {
-                return item[options.tagsInput.displayProperty];
+                return item[displayProperty];
             };
 
             scope.suggestionList = suggestionList;


### PR DESCRIPTION
This means that the displayed tag and the displayed suggestions can show different things, for example tag is user first name, autocomplete suggestions shows full name plus email.
