### PR TITLE
Fixed ngClick not being triggered on autocomplete items

### DIFF
--- a/templates/auto-complete.html
+++ b/templates/auto-complete.html
@@ -3,7 +3,7 @@
     <li class="suggestion-item"
         ng-repeat="item in suggestionList.items track by track(item)"
         ng-class="{selected: item == suggestionList.selected}"
-        ng-click="addSuggestion()"
+        ng-mousedown="addSuggestion()"
         ng-mouseenter="suggestionList.select($index)"
         ng-bind-html="highlight(item)"></li>
   </ul>


### PR DESCRIPTION
Fix to issue https://github.com/mbenford/ngTagsInput/issues/146.

On certain cases, the autocomplete items do not trigger addSuggestion() on click. To fix this, I've changed ng-click to ng-mousedown, on the auto-complete.html template.
