### PR TITLE
feat(bootstrap): add bootstrap-compatible stylesheet

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,11 @@ module.exports = function(grunt) {
                 out: 'build/<%= pkg.name %>.css',
                 outMin: 'build/<%= pkg.name %>.min.css'
             },
+            bootstrapCss: {
+                src: 'scss/bootstrap.scss',
+                out: 'build/<%= pkg.name %>-bootstrap.css',
+                outMin: 'build/<%= pkg.name %>-bootstrap.min.css'
+            },
             html: {
                 src: ['templates/tags-input.html', 'templates/auto-complete.html'],
                 out: 'tmp/templates.js'
@@ -146,7 +151,8 @@ module.exports = function(grunt) {
                     noCache: true
                 },
                 files: {
-                    '<%= files.css.out %>': ['<%= files.css.src %>']
+                    '<%= files.css.out %>': ['<%= files.css.src %>'],
+                    '<%= files.bootstrapCss.out %>': ['<%= files.bootstrapCss.src %>']
                 }
             }
         },
@@ -165,7 +171,8 @@ module.exports = function(grunt) {
         cssmin: {
             build: {
                 files: {
-                    '<%= files.css.outMin %>': ['<%= files.css.out %>']
+                    '<%= files.css.outMin %>': ['<%= files.css.out %>'],
+                    '<%= files.bootstrapCss.outMin %>': ['<%= files.bootstrapCss.out %>']
                 }
             }
         },

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,0 +1,49 @@
+@import "main";
+
+tags-input  {
+  .tags {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    &.focused {
+      border-color: #66afe9;
+      box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
+    }
+    .tag-item {
+      background: #428bca;
+      border: 1px solid #357ebd;
+      border-radius: 4px;
+      color: #fff;
+      &.selected {
+        background: #d9534f;
+        border: 1px solid #d43f3a;
+        border-radius: 4px;
+        color: #fff;
+      }
+      button {
+        background: transparent;
+        color: #000;
+        opacity: .4;
+      }
+    }
+  }
+  .autocomplete {
+    border-radius: 4px;
+    .suggestion-item {
+      &.selected {
+        color: #262626;
+        background-color: #e9e9e9;
+        em {
+          color: #262626;
+          background-color: #ffff00;
+        }
+      }
+      em {
+        font-weight: normal;
+        background-color: #ffff00;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Now build includes the separate `ng-tags-input-bootstrap.css` stylesheet (and `-min` version) which contains all styles from main and some overrides for bootstrap-like skinning.

closes #78
