### PR TITLE
feat(tagsinput): add addOnSemicolon option

### DIFF
--- a/src/keycodes.js
+++ b/src/keycodes.js
@@ -8,5 +8,6 @@ var KEYS = {
     space: 32,
     up: 38,
     down: 40,
-    comma: 188
+    comma: 188,
+    semicolon: 186
 };

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -22,6 +22,7 @@
  * @param {boolean=} [addOnEnter=true] Flag indicating that a new tag will be added on pressing the ENTER key.
  * @param {boolean=} [addOnSpace=false] Flag indicating that a new tag will be added on pressing the SPACE key.
  * @param {boolean=} [addOnComma=true] Flag indicating that a new tag will be added on pressing the COMMA key.
+ * @param {boolean=} [addOnSemicolon=true] Flag indicating that a new tag will be added on pressing the SEMICOLON key.
  * @param {boolean=} [addOnBlur=true] Flag indicating that a new tag will be added when the input field loses focus.
  * @param {boolean=} [replaceSpacesWithDashes=true] Flag indicating that spaces will be replaced with dashes.
  * @param {string=} [allowedTagsPattern=.+] Regular expression that determines whether a new tag is valid.
@@ -29,7 +30,7 @@
  *                                                the new tag input box instead of being removed when the backspace key
  *                                                is pressed and the input box is empty.
  * @param {boolean=} [addFromAutocompleteOnly=false] Flag indicating that only tags coming from the autocomplete list will be allowed.
- *                                                   When this flag is true, addOnEnter, addOnComma, addOnSpace, addOnBlur and
+ *                                                   When this flag is true, addOnEnter, addOnComma, addOnSemicolon,  addOnSpace, addOnBlur and
  *                                                   allowLeftoverText values are ignored.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
@@ -128,6 +129,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 addOnEnter: [Boolean, true],
                 addOnSpace: [Boolean, false],
                 addOnComma: [Boolean, true],
+                addOnSemicolon: [Boolean, true],
                 addOnBlur: [Boolean, true],
                 allowedTagsPattern: [RegExp, /.+/],
                 enableEditingLastTag: [Boolean, false],
@@ -168,7 +170,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             };
         },
         link: function(scope, element, attrs, ngModelCtrl) {
-            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace],
+            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.semicolon, KEYS.space, KEYS.backspace],
                 tagList = scope.tagList,
                 events = scope.events,
                 options = scope.options,
@@ -247,6 +249,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
 
                     addKeys[KEYS.enter] = options.addOnEnter;
                     addKeys[KEYS.comma] = options.addOnComma;
+                    addKeys[KEYS.semicolon] = options.addOnSemicolon;
                     addKeys[KEYS.space] = options.addOnSpace;
 
                     shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -317,7 +317,7 @@ describe('tags-input directive', function() {
             expect($scope.$digest).not.toHaveBeenCalled();
         });
     });
-    
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act
@@ -421,6 +421,38 @@ describe('tags-input directive', function() {
 
             // Assert
             expect(isolateScope.options.addOnComma).toBe(true);
+        });
+    });
+
+    describe('add-on-semicolon option', function() {
+        it('adds a new tag when the semicolon key is pressed and the option is true', function() {
+            // Arrange
+            compile('add-on-semicolon="true"');
+
+            // Act
+            newTag('foo', KEYS.semicolon);
+
+            // Assert
+            expect($scope.tags).toEqual([{ text: 'foo' }]);
+        });
+
+        it('does not add a new tag when the semicolon key is pressed and the option is false', function() {
+            // Arrange
+            compile('add-on-semicolon="false"');
+
+            // Act
+            newTag('foo', KEYS.semicolon);
+
+            // Assert
+            expect($scope.tags).toEqual([]);
+        });
+
+        it('initializes the option to true', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.addOnSemicolon).toBe(true);
         });
     });
 
@@ -1011,7 +1043,7 @@ describe('tags-input directive', function() {
         describe('option is true', function() {
             beforeEach(function() {
                 compileWithForm('add-from-autocomplete-only="true"', 'name="tags"', 'allow-leftover-text="false"',
-                    'add-on-blur="true"', 'add-on-enter="true"', 'add-on-comma="true"', 'add-on-space="true"');
+                    'add-on-blur="true"', 'add-on-enter="true"', 'add-on-comma="true"', 'add-on-semicolon="true"', 'add-on-space="true"');
             });
 
             it('does not add a tag when the enter key is pressed', function() {
@@ -1025,6 +1057,14 @@ describe('tags-input directive', function() {
             it('does not add a tag when the comma key is pressed', function() {
                 // Act
                 newTag('foo', KEYS.comma);
+
+                // Assert
+                expect($scope.tags).toEqual([]);
+            });
+
+            it('does not add a tag when the semicolon key is pressed', function() {
+                // Act
+                newTag('foo', KEYS.semicolon);
 
                 // Assert
                 expect($scope.tags).toEqual([]);
@@ -1195,12 +1235,12 @@ describe('tags-input directive', function() {
         var hotkeys;
 
         beforeEach(function() {
-            compile('add-on-enter="true"', 'add-on-space="true"', 'add-on-comma="true"');
+            compile('add-on-enter="true"', 'add-on-space="true"', 'add-on-comma="true"', 'add-on-semicolon="true"');
         });
 
         describe('modifier key is on', function() {
             beforeEach(function() {
-                hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace];
+                hotkeys = [KEYS.enter, KEYS.comma, KEYS.semicolon, KEYS.space, KEYS.backspace];
             });
 
             it('does not prevent any hotkey from being propagated when the shift key is down', function() {
@@ -1232,7 +1272,7 @@ describe('tags-input directive', function() {
         describe('modifier key is off', function() {
             it('prevents enter, comma and space keys from being propagated when all modifiers are up', function() {
                 // Arrange
-                hotkeys = [KEYS.enter, KEYS.comma, KEYS.space];
+                hotkeys = [KEYS.enter, KEYS.comma, KEYS.semicolon, KEYS.space];
 
                 // Act/Assert
                 angular.forEach(hotkeys, function(key) {


### PR DESCRIPTION
Add an option for the user to set if a new tag should be created when
the semicolon key is pressed. This is important because in larger
applications people often copy emails or data from an CSV file.
