### PR TITLE
feat(tagsInput): add support for pasting a collection of tags

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -118,7 +118,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
         scope: {
             tags: '=ngModel',
             onTagAdded: '&',
-            onTagRemoved: '&'
+            onTagRemoved: '&',
+            separatorList: '@'
         },
         replace: false,
         transclude: true,
@@ -181,6 +182,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 events = scope.events,
                 options = scope.options,
                 input = element.find('input'),
+                separatorList = scope.separatorList,
                 validationOptions = ['minTags', 'maxTags', 'allowLeftoverText'],
                 setElementValidity;
 
@@ -236,6 +238,27 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
 
             scope.newTagChange = function() {
                 events.trigger('input-change', scope.newTag.text);
+            };
+
+            scope.newTagPasted = function(clipboard) {
+                var rawInput = clipboard.clipboardData.getData('text/plain');
+
+                var match = /\/(.*)\//.exec(separatorList),
+                separator = match && new RegExp(match[1]) || separatorList || ',';
+
+                var tags = rawInput.split(separator);
+
+                if(tags.length <= 1) {
+                    return;
+                }
+
+                angular.forEach(tags, function(tag) {
+                    tagList.addText(tag);
+                });
+
+                $timeout(function() {
+                    events.trigger('tag-added');
+                });
             };
 
             scope.$watch('tags', function(value) {

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -9,6 +9,7 @@
     <input class="input"
            ng-model="newTag.text"
            ng-change="newTagChange()"
+           ng-paste="newTagPasted($event)"
            ng-trim="false"
            ng-class="{'invalid-tag': newTag.invalid}"
            ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex}"

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -339,7 +339,7 @@ describe('tags-input directive', function() {
             expect($scope.$digest).not.toHaveBeenCalled();
         });
     });
-    
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act
@@ -562,6 +562,76 @@ describe('tags-input directive', function() {
 
             // Assert
             expect(getInput().attr('type')).toBe('text');
+        });
+    });
+
+    describe('add-on-paste option', function() {
+        var body;
+        // mock object for clipboard event
+        var clipboardMock = {
+            clipboardData: {
+                getData: function(type) {
+                    return 'item1, item2; item3 item4';
+                }
+            }
+        };
+
+        it('does split the string into multiple tags if the separators are defined in the regex', function() {
+            // compile
+            compile('separator-list="/[,;| ]/"');
+
+            body = $document.find('body');
+            body.append(element);
+
+            isolateScope.newTagPasted(clipboardMock);
+            // Assert
+            expect($scope.tags).toEqual([{
+                'text': 'item1'
+            }, {
+                'text': 'item2'
+            }, {
+                'text': 'item3'
+            }, {
+                'text': 'item4'
+            }]);
+        });
+
+        it('does split the string into multiple tags if the separators are defined in the regex', function() {
+            // compile
+            compile('separator-list="/[,;| ]/"');
+
+            body = $document.find('body');
+            body.append(element);
+
+            isolateScope.newTagPasted(clipboardMock);
+            // Assert
+            expect($scope.tags).toEqual([{
+                'text': 'item1'
+            }, {
+                'text': 'item2'
+            }, {
+                'text': 'item3'
+            }, {
+                'text': 'item4'
+            }]);
+        });
+
+        it('doesn\'t split part of the string if the used separator is not defined in the regex', function() {
+            // compile
+            compile('separator-list="/[,;|]/"');
+
+            body = $document.find('body');
+            body.append(element);
+
+            isolateScope.newTagPasted(clipboardMock);
+            // Assert
+            expect($scope.tags).toEqual([{
+                'text': 'item1'
+            }, {
+                'text': 'item2'
+            }, {
+                'text': 'item3-item4'
+            }]);
         });
     });
 

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -16,9 +16,9 @@
 
     .foo .tags .input {
       width: 1036px;
-      
+
     }
-    
+
     .foo .tags .tag-item {
       height: 50px;
     }


### PR DESCRIPTION
This pullrequest adds functionality that allows a user to paste a coma
separated string instead of having to type all entries manually. the
pasted string will be parsed to tags and the invalid ones will be
discarded.
