### PR TITLE
feat(tagsInput): Add onBlur option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -33,6 +33,7 @@
  *                                                   allowLeftoverText values are ignored.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
+ * @param {expression} onBlur Expression to evaluate when the input field loses focus.
  */
 tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) {
     function TagList(options, events) {
@@ -112,7 +113,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
         scope: {
             tags: '=ngModel',
             onTagAdded: '&',
-            onTagRemoved: '&'
+            onTagRemoved: '&',
+            onBlur: '&'
         },
         replace: false,
         transclude: true,
@@ -194,6 +196,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     ngModelCtrl.$setValidity('leftoverText', true);
                 })
                 .on('input-blur', function() {
+                    scope.onBlur();
+
                     if (!options.addFromAutocompleteOnly) {
                         if (options.addOnBlur) {
                             tagList.addText(scope.newTag.text);

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1106,6 +1106,21 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('on-blur option', function () {
+        it ('calls the provided callback when the input field loses focus', function() {
+            // Arrange
+            $scope.callback = jasmine.createSpy();
+            compile('on-blur="callback()"');
+
+            // Act
+            getInput().triggerHandler('blur');
+            $timeout.flush();
+
+            // Assert
+            expect($scope.callback).toHaveBeenCalled();
+        });
+    });
+
     describe('autocomplete registration', function() {
         var autocompleteObj;
 

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -50,7 +50,8 @@
                 placeholder="{{placeholder}}"
                 remove-tag-symbol="{{removeTagSymbol}}"
                 max-length="5"
-                add-from-autocomplete-only="false">
+                add-from-autocomplete-only="false"
+                on-blur="hideInputField()">
       <auto-complete source="loadItems2($query)"
                      debounce-delay="0"
                      min-length="1"
@@ -80,6 +81,13 @@
               { text: 'Green Arrow' },
               { text: 'Spiderman'}
             ];
+
+            $scope.hideInputField = function() {
+              // here we could trigger storing the tags
+
+              // hide the input field
+              $scope.visible = false;
+            }
 
             $scope.tags = [{ text: 'Batman' }, { text: 'Superman' }, { text:'Flash' }];
             $scope.placeholder = 'New tag';


### PR DESCRIPTION
Add an onBlur option in order to evaluate an expression when the input field loses focus. This feature can for instance be used to save the tags on blur.
