### PR TITLE
feat(tagsInput): add callback option for invalid-tag event

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -32,6 +32,7 @@
  *                                                   When this flag is true, addOnEnter, addOnComma, addOnSpace, addOnBlur and
  *                                                   allowLeftoverText values are ignored.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
+ * @param {expression} onInvalidTag Expression to evaluate when a parsed tag is invalid. The invalid tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
  */
 tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) {
@@ -112,6 +113,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
         scope: {
             tags: '=ngModel',
             onTagAdded: '&',
+            onInvalidTag: '&',
             onTagRemoved: '&'
         },
         replace: false,
@@ -176,6 +178,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
 
             events
                 .on('tag-added', scope.onTagAdded)
+                .on('invalid-tag',scope.onInvalidTag)
                 .on('tag-removed', scope.onTagRemoved)
                 .on('tag-added', function() {
                     scope.newTag.text = '';

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -317,7 +317,7 @@ describe('tags-input directive', function() {
             expect($scope.$digest).not.toHaveBeenCalled();
         });
     });
-    
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act
@@ -1068,6 +1068,20 @@ describe('tags-input directive', function() {
             // Arrange
             $scope.callback = jasmine.createSpy();
             compile('on-tag-added="callback($tag)"');
+
+            // Act
+            newTag('foo');
+
+            // Assert
+            expect($scope.callback).toHaveBeenCalledWith({ text: 'foo' });
+        });
+    });
+
+    describe('on-invalid-tag option', function() {
+        it('calls the provided callback when a invalid tag is added', function() {
+            // Arrange
+            $scope.callback = jasmine.createSpy();
+            compile('on-invalid-tag="callback($tag)" allowed-tags-pattern="^[a-z]+@[a-z]+\\.com$"');
 
             // Act
             newTag('foo');


### PR DESCRIPTION
This pullrequest adds the option for developers to specify a callback
that gets triggered whenever a tag is invalid. This makes it easier
for developers to add custom event handlers for this event.

this especially makes it easier for developers that use https://github.com/mbenford/ngTagsInput/pull/179 to notify the user what tags in their pasted string are invalid.

**a common use case where this feature is required:**
say i have the following tags-input implementation:

``` html
<tags-input ng-model="emails"
                   name="emails"
                   display-property="email"
                   placeholder="add recipient"
                   min-length="5"
                   min-tags="1"
                   separator-list="/[,;| ]/"
                   allowed-tags-pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
                   on-tag-added="tagAdded($tag)">
</tags-input>
```

The regex used in the `allowed-tags-pattern` attribute is a regex that validates if the pasted tag is in the format: `example@domain.com`.

when i paste the following comma separated string: `example@domain.com, invalid@aoeu, example+2@gmail.com` the following happens:
1. the `newTagPasted` method get's called and splits the string on `,` 
2. It will call the `tagList.addText` method that depending on the validity of the tag will either call trigger the `onTagAdded` or `invalidTag` event.

Often in a scenario where users paste larger collections / strings we want to know what tags aren't valid. In this example i might want to know that the second  email in my string was invalid.
