### PR TITLE
fix(tagsInput): ignore addFromAutocompleteOnly option on validate

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -210,13 +210,10 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     ngModelCtrl.$setValidity('leftoverText', true);
                 })
                 .on('input-blur', function() {
-                    if (!options.addFromAutocompleteOnly) {
-                        if (options.addOnBlur) {
-                            tagList.addText(scope.newTag.text);
-                        }
-
-                        setElementValidity();
+                    if(!options.addFromAutocompleteOnly && options.addOnBlur) {
+                        tagList.addText(scope.newTag.text);
                     }
+                    setElementValidity();
                 })
                 .on('option-change', function(e) {
                     if (validationOptions.indexOf(e.name) !== -1) {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1155,9 +1155,21 @@ describe('tags-input directive', function() {
                 expect(isolateScope.tags).toEqual([]);
             });
 
-            it('does not make the element invalid when it loses focus and there is any leftover text', function() {
+            it('should make the element invalid when it loses focus and there is any leftover text', function() {
                 // Arrange
                 isolateScope.newTag.text = 'foo';
+
+                // Act
+                isolateScope.events.trigger('input-blur');
+
+                // Assert
+                expect($scope.form.tags.$valid).toBe(false);
+                expect($scope.form.tags.$error.leftoverText).toBeTruthy();
+            });
+
+            it('does not make the element invalid when it loses focus and there is no leftover text', function() {
+                // Arrange
+                isolateScope.newTag.text = '';
 
                 // Act
                 isolateScope.events.trigger('input-blur');


### PR DESCRIPTION
I don't see a case when the current behavior is useful. But with by changes it would be able to prevent submit when user made a typo and value didn't match into auto-complete.
