### PR TITLE
Fixed CSS that assigned border-box to *:before and *:after

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,4 +1,4 @@
-tags-input *, *:before, *:after {
+tags-input *, tags-input *:before, tags-input *:after {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
Precedence error with commas in a CSS selector.
