### PR TITLE
fix(tags-input.html): disable spellcheck

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -32,6 +32,7 @@
  * @param {boolean=} [addFromAutocompleteOnly=false] Flag indicating that only tags coming from the autocomplete list will be allowed.
  *                                                   When this flag is true, addOnEnter, addOnComma, addOnSpace, addOnBlur and
  *                                                   allowLeftoverText values are ignored.
+ * @param {boolean=} [spellcheck=true] Flag indicating whether the browser's spellcheck is enabled for the input field or not.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
  */
@@ -144,7 +145,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 maxTags: [Number, MAX_SAFE_INTEGER],
                 displayProperty: [String, 'text'],
                 allowLeftoverText: [Boolean, false],
-                addFromAutocompleteOnly: [Boolean, false]
+                addFromAutocompleteOnly: [Boolean, false],
+                spellcheck: [Boolean, true]
             });
 
             $scope.tagList = new TagList($scope.options, $scope.events);

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -11,7 +11,7 @@
            ng-change="newTagChange()"
            ng-trim="false"
            ng-class="{'invalid-tag': newTag.invalid}"
-           ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex}"
+           ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex, spellcheck: options.spellcheck}"
            ti-autosize>
   </div>
 </div>

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -565,6 +565,26 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('spellcheck option', function() {
+        it('sets the input\'s spellcheck property properly', function() {
+            [true, false].forEach(function(spellcheck) {
+                // Arrange/Act
+                compile('spellcheck="' + spellcheck + '"');
+
+                // Assert
+                expect(getInput().attr('spellcheck')).toBe(spellcheck.toString());
+            });
+        });
+
+        it('initializes the option to "true"', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.spellcheck).toBe(true);
+        });
+    });
+
     describe('placeholder option', function() {
         it('sets the input\'s placeholder text', function() {
             // Arrange/Act


### PR DESCRIPTION
Often times tags are not actual dictionary words. This removes the red underline added by some browsers.
