### PR TITLE
feat(autocomplete) remove promise requirement from loadFn result

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -26,7 +26,7 @@
  * @param {boolean=} {loadOnFocus=false} Flag indicating that the source option will be evaluated when the input element
  *                                       gains focus. The current input value is available as $query.
  */
-tagsInput.directive('autoComplete', function($document, $timeout, $sce, tagsInputConfig) {
+tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig) {
     function SuggestionList(loadFn, options) {
         var self = {}, debouncedLoadId, getDifference, lastPromise;
 
@@ -56,7 +56,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, tagsInpu
             debouncedLoadId = $timeout(function() {
                 self.query = query;
 
-                var promise = loadFn({ $query: query });
+                var promise = $q.when(loadFn({ $query: query }));
                 lastPromise = promise;
 
                 promise.then(function(items) {

--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -113,6 +113,16 @@ describe('autoComplete directive', function() {
             expect(isSuggestionsBoxVisible()).toBe(false);
         });
 
+        it('loads values from the load function even if the return value is not a promise', function() {
+            // Arrange
+            $scope.loadItems = jasmine.createSpy().and.returnValue(generateSuggestions(3));
+            // Act
+            suggestionList.load('', []);
+            $timeout.flush();
+            // Assert
+            expect(getSuggestions().length).toBe(3);
+        });
+
         it('renders all elements returned by the load function that aren\'t already added', function() {
             // Act
             tagsInput.getTags.and.returnValue([{ text: 'Item3' }]);


### PR DESCRIPTION
Use $q.when to remove api restriction that the result of loadFn must be a promise.
This is a simple non-breaking addition which makes the API more simple to use.

Closes #237
