### PR TITLE
bug(tagsInput): tab and shift+tab move focus correctly within form

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -98,6 +98,9 @@ tagsInput.provider('tagsInputConfig', function() {
                     }
                     else {
                         updateValue(attrs[key] && $interpolate(attrs[key])(scope.$parent));
+                        if(key==='tabindex') {
+                            attrs[key] = -1; // fixes tab key entering input correctly
+                        }
                     }
                 });
             },

--- a/test/configuration.spec.js
+++ b/test/configuration.spec.js
@@ -72,6 +72,24 @@ describe('configuration service', function() {
         });
     });
 
+    it('loads sets tabindex to -1 for root element', function() {
+        // Arrange
+        $scope.$parent.tabindex = 2;
+
+        attrs.tabindex = '{{ tabindex }}';
+
+        // Act
+        service.load('foo', $scope, attrs, {
+            tabindex: [Number]
+        });
+
+        // Assert
+        expect($scope.options).toEqual({
+            tabindex: 2
+        });
+        expect(attrs.tabindex).toEqual(-1);
+    });
+
     it('loads interpolated values from attributes as they change', function() {
         // Arrange
         provider.setActiveInterpolation('foo', { prop2: true, prop4: true });


### PR DESCRIPTION
This makes it so you can tab into the tags-input instead of needing to double tab. It also fixes the same issue when shift+tabbing out of the input.

Fixes #242
