### PR TITLE
fix(tags-input): allow "enter" key propagation with empty input value

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -276,6 +276,12 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     shouldRemove = !shouldAdd && key === KEYS.backspace && scope.newTag.text.length === 0;
 
                     if (shouldAdd) {
+                        // Skip adding tag if input value is empty and enter key is pressed.
+                        // Allows form submission on-enter to proceed.
+                        if (!scope.newTag.text && key === KEYS.enter) {
+                            return;
+                        }
+
                         tagList.addText(scope.newTag.text);
 
                         scope.$apply();

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1348,9 +1348,26 @@ describe('tags-input directive', function() {
         });
 
         describe('modifier key is off', function() {
-            it('prevents enter, comma and space keys from being propagated when all modifiers are up', function() {
+            it('prevents enter, comma and space keys from being propagated when all modifiers are up and there is an input value', function() {
                 // Arrange
                 hotkeys = [KEYS.enter, KEYS.comma, KEYS.space];
+                changeInputValue('ABC');
+
+                // Act/Assert
+                angular.forEach(hotkeys, function(key) {
+                    expect(sendKeyDown(key, {
+                        shiftKey: false,
+                        ctrlKey: false,
+                        altKey: false,
+                        metaKey: false
+                    }).isDefaultPrevented()).toBe(true);
+                });
+            });
+
+            it('prevents comma and space keys from being propagated when all modifiers are up and there is no value', function() {
+                // Arrange
+                hotkeys = [KEYS.comma, KEYS.space];
+                changeInputValue('');
 
                 // Act/Assert
                 angular.forEach(hotkeys, function(key) {


### PR DESCRIPTION
I have a use-case where I'm using the tags-input directive inside a search form (with no submit button). The current unconditional `enter` key event capturing makes it impossible to submit the form. I think it makes sense to allow enter events to propagate only when the input field is completely empty.
