### PR TITLE
fix(autocomplete): check elementValidity on blur if addFromAutoCompleteOnly is set

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -217,9 +217,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                         if (options.addOnBlur) {
                             tagList.addText(scope.newTag.text);
                         }
-
-                        setElementValidity();
                     }
+                    setElementValidity();
                 })
                 .on('option-change', function(e) {
                     if (validationOptions.indexOf(e.name) !== -1) {


### PR DESCRIPTION
Correct me if i'm wrong but element validity on input blur should also be set when addFromAutocompleteOnly is true ? (i'm using it for leftovertext but mintags & maxtags applies also)
