### PR TITLE
Added "caseSensitive" parameter 

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -32,7 +32,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, tagsInpu
 
         getDifference = function(array1, array2) {
             return array1.filter(function(item) {
-                return !findInObjectArray(array2, item, options.tagsInput.displayProperty);
+                return !findInObjectArray(array2, item, options.tagsInput.displayProperty, options.tagsInput.caseSensitive);
             });
         };
 

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -34,6 +34,7 @@
  *                                                   allowLeftoverText values are ignored.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
+ * @param {boolean=} [caseSensitive=false] Defines if the uniqueness check of each tag is case sensitive or not
  */
 tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) {
     function TagList(options, events) {
@@ -54,7 +55,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                    tagText.length >= options.minLength &&
                    tagText.length <= options.maxLength &&
                    options.allowedTagsPattern.test(tagText) &&
-                   !findInObjectArray(self.items, tag, options.displayProperty);
+                   !findInObjectArray(self.items, tag, options.displayProperty, options.caseSensitive);
         };
 
         self.items = [];
@@ -144,7 +145,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 maxTags: [Number, MAX_SAFE_INTEGER],
                 displayProperty: [String, 'text'],
                 allowLeftoverText: [Boolean, false],
-                addFromAutocompleteOnly: [Boolean, false]
+                addFromAutocompleteOnly: [Boolean, false],
+                caseSensitive: [Boolean, false]
             });
 
             $scope.tagList = new TagList($scope.options, $scope.events);

--- a/src/util.js
+++ b/src/util.js
@@ -32,15 +32,23 @@ function makeObjectArray(array, key) {
     return array;
 }
 
-function findInObjectArray(array, obj, key) {
+function findInObjectArray(array, obj, key, caseSensitive) {
     var item = null;
     for (var i = 0; i < array.length; i++) {
         // I'm aware of the internationalization issues regarding toLowerCase()
         // but I couldn't come up with a better solution right now
-        if (safeToString(array[i][key]).toLowerCase() === safeToString(obj[key]).toLowerCase()) {
-            item = array[i];
-            break;
+        if(!caseSensitive){
+            if (safeToString(array[i][key]).toLowerCase() === safeToString(obj[key]).toLowerCase()) {
+                item = array[i];
+                break;
+            }
+        } else {
+            if (safeToString(array[i][key]) === safeToString(obj[key])) {
+                item = array[i];
+                break;
+            }
         }
+
     }
     return item;
 }


### PR DESCRIPTION
Currently before accepting new entries on the input there's a check that checks whether this tag is already present. This check is case insensitive. 
Though, there are occasions where capital letters matter. For this reason I added a new (boolean) parameter called "caseSensitive". This parameter is by default "false" (that means the input checks tags existence in a case-insensitive manner, exactly as it is now). 
If the user wants to make the check case-sensitive then he can enter this parameter with value "true" on the tag.
Example: 
-- without case-sensitive
Having entered the "abc" tag in the input "Abc" is not acceptable
-- with case-sensitive="true"
Having entered the "abc" tag in the input "Abc" is also accaptable