### PR TITLE
fix(*): repopulate suggestions when load-on-empty is true

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -292,13 +292,13 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     }
                 })
                 .on('focus', function() {
+                    events.trigger('input-focus');
+
                     if (scope.hasFocus) {
                         return;
                     }
 
                     scope.hasFocus = true;
-                    events.trigger('input-focus');
-
                     scope.$apply();
                 })
                 .on('blur', function() {

--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -723,6 +723,56 @@ describe('autoComplete directive', function() {
             expect($scope.loadItems).toHaveBeenCalledWith('');
         });
 
+        it('calls the load function after a tag is added and the option is true', function(){
+            // Arrange
+            compile('load-on-empty="true"');
+            tagsInput.getCurrentTagText.and.returnValue('');
+
+            // Act
+            eventHandlers['tag-added']();
+            $timeout.flush();
+
+            // Assert
+            expect($scope.loadItems).toHaveBeenCalledWith('');
+        });
+
+        it('doesn\'t call the load function after a tag is added and the option is false', function(){
+            // Arrange
+            compile('load-on-empty="false"');
+
+            // Act
+            eventHandlers['tag-added']();
+            $timeout.flush();
+
+            // Assert
+            expect($scope.loadItems).not.toHaveBeenCalled();
+        });
+
+        it('calls the load function after a tag is removed and the option is true', function(){
+            // Arrange
+            compile('load-on-empty="true"');
+            tagsInput.getCurrentTagText.and.returnValue('');
+
+            // Act
+            eventHandlers['tag-removed']();
+            $timeout.flush();
+
+            // Assert
+            expect($scope.loadItems).toHaveBeenCalledWith('');
+        });
+
+        it('doesn\'t call the load function after a tag is removed and the option is false', function(){
+            // Arrange
+            compile('load-on-empty="false"');
+
+            // Act
+            eventHandlers['tag-removed']();
+            $timeout.flush();
+
+            // Assert
+            expect($scope.loadItems).not.toHaveBeenCalled();
+        });
+
         it('doesn\'t call the load function when the input field becomes empty and the option is false', function(){
             // Arrange
             compile('load-on-empty="false"');

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -338,8 +338,20 @@ describe('tags-input directive', function() {
             // Assert
             expect($scope.$digest).not.toHaveBeenCalled();
         });
+
+        it('always triggers the input-focus event', function () {
+            // Arrange
+            isolateScope.hasFocus = true;
+            spyOn(isolateScope.events, 'trigger');
+
+            // Act
+            getInput().triggerHandler('focus');
+
+            // Assert
+            expect(isolateScope.events.trigger).toHaveBeenCalledWith('input-focus');
+        });
     });
-    
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act


### PR DESCRIPTION
It may be worth playing with this kind of behaviour before pulling this stuff. The basic idea is that when you add/remove a tag and load-on-empty is true, the suggestions list is repopulated rather than just being hidden.

Closes #251 
