### PR TITLE
feat(tagsInput): Provide leftover-text to view

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -198,6 +198,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 .on('tag-removed', scope.onTagRemoved)
                 .on('tag-added', function() {
                     scope.newTag.text = '';
+                    ngModelCtrl._leftoverText = '';
                 })
                 .on('tag-added tag-removed', function() {
                     ngModelCtrl.$setViewValue(scope.tags);
@@ -208,6 +209,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 .on('input-change', function() {
                     tagList.selected = null;
                     scope.newTag.invalid = null;
+                    ngModelCtrl._leftoverText = scope.newTag.text;
                 })
                 .on('input-focus', function() {
                     ngModelCtrl.$setValidity('leftoverText', true);
@@ -228,6 +230,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 });
 
             scope.newTag = { text: '', invalid: null };
+            ngModelCtrl._leftoverText = '';
 
             scope.getDisplayText = function(tag) {
                 return safeToString(tag[options.displayProperty]);

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -339,7 +339,7 @@ describe('tags-input directive', function() {
             expect($scope.$digest).not.toHaveBeenCalled();
         });
     });
-    
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act
@@ -1104,6 +1104,20 @@ describe('tags-input directive', function() {
             // Assert
             expect($scope.form.tags.$invalid).toBe(true);
             expect($scope.form.tags.$error.leftoverText).toBe(true);
+        });
+
+        it('makes the leftover-text content available to the view', function () {
+            // Arrange
+            compileWithForm('allow-leftover-text="false"', 'name="tags"');
+            newTag('foo');
+            newTag('Foo');
+
+            // Act
+            isolateScope.events.trigger('input-blur');
+
+            // Assert
+            expect($scope.form.tags.$invalid).toBe(true);
+            expect($scope.form.tags._leftoverText).toEqual('Foo');
         });
     });
 


### PR DESCRIPTION
Provide the content of the leftover-text to the view . This feature
allows more flexibility for error reporting when handling incorrect inputs.