### PR TITLE
in suggestionList.load(), tell $timeout to use $apply so suggestion list can be rendered in sync with updates

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -75,7 +75,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, tagsInpu
                         self.reset();
                     }
                 });
-            }, options.debounceDelay, false);
+            }, options.debounceDelay, true);
         };
         self.selectNext = function() {
             self.select(++self.index);


### PR DESCRIPTION
To replicate error: Set autocomplete `minLength` to 1. Typing 1 character does not result in a the suggestion being rendered, even though there are results. You can also try typing multiple characters really fast (or set debounce to a value like 300 or 500) and see that the first batch of quickly typed character yields no rendering of the suggestion list either. This also happen in a repeatable way during the autocomplete process (the list being rendered is not always in sync with the queried result).

After some tracing, I think the debouncing mechanism is causing suggestion list updates to miss their turns in the $digest cycle. Setting the 3rd parameter of $timeout to `true` will ensure `$apply` is called and fix this issue.
