### PR TITLE
Not setting tags explicitly

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -193,8 +193,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 setElementValidity;
 
             setElementValidity = function() {
-                ngModelCtrl.$setValidity('maxTags', scope.tags.length <= options.maxTags);
-                ngModelCtrl.$setValidity('minTags', scope.tags.length >= options.minTags);
+                var tagsLength = (scope.tags && scope.tags.length) || 0;
+                ngModelCtrl.$setValidity('maxTags', tagsLength <= options.maxTags);
+                ngModelCtrl.$setValidity('minTags', tagsLength >= options.minTags);
                 ngModelCtrl.$setValidity('leftoverText', options.allowLeftoverText ? true : !scope.newTag.text);
             };
 
@@ -209,8 +210,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             };
 
             scope.$watch('tags', function(value) {
-                scope.tags = makeObjectArray(value, options.displayProperty);
-                tagList.items = scope.tags;
+                tagList.items = makeObjectArray(value, options.displayProperty);
             });
 
             scope.$watch('tags.length', function() {


### PR DESCRIPTION
Not setting tags explicitly as that circumvents ng-model and can create invalid models on parent, especially when model hasn't been loaded yet (tags === undefined)

Consider the following scenario

``` html
<tags-input ng-model="someObject.metadata.tags"></tags-input>
```

With the previous code, if `someObj` was undefined/null, tagsInput would create the whole `someObj.metadata` objects as empty objects with one property `tags` that would be an empty array. With the only seeming reason being that you can count on running `scope.tags.length`.  This could invalidate any validations on the parent. Allowing for `scope.tags` to be undefined/null should be up to the consumer, and the value shold only be set through `$ngModelCtrl.setViewModel()`
