### PR TITLE
feat(tagsInput): add newTagText option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -9,6 +9,7 @@
  * Renders an input box with tag editing support.
  *
  * @param {string} ngModel Assignable angular expression to data-bind to.
+ * @param {string} newTagText Assignable angular expression for data-binding to the underlying input for a new tag.
  * @param {string=} [displayProperty=text] Property to be rendered as the tag label.
  * @param {string=} [keyProperty=text] Property to be used as a unique identifier for the tag.
  * @param {string=} [type=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
@@ -129,6 +130,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
         require: 'ngModel',
         scope: {
             tags: '=ngModel',
+            newTagText: '=?',
             onTagAdding: '&',
             onTagAdded: '&',
             onInvalidTag: '&',
@@ -219,6 +221,18 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
                     events.trigger('input-change', value);
                 }
             };
+
+            scope.$watch('newTag.text', function(value) {
+                if(scope.newTag.text !== scope.newTagText) {
+                    scope.newTagText = value;
+                }
+            });
+
+            scope.$watch('newTagText', function(value) {
+                if(scope.newTag.text !== scope.newTagText) {
+                    scope.newTag.setText(value);
+                }
+            });
 
             scope.getDisplayText = function(tag) {
                 return tiUtil.safeToString(tag[options.displayProperty]);

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -437,6 +437,33 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('new-tag-text option', function() {
+        it('updates as text is typed into the input field', function() {
+            // Arrange
+            compile('new-tag-text="innerModel"');
+
+            // Act
+            sendKeyPress('f'.charCodeAt(0));
+            sendKeyPress('o'.charCodeAt(0));
+            sendKeyPress('o'.charCodeAt(0));
+
+            // Assert
+            expect($scope.innerModel).toEqual('foo');
+        });
+
+        it('updates the input field as the scope\'s model changes', function() {
+            // Arrange
+            compile('new-tag-text="innerModel"');
+
+            // Act
+            $scope.innerModel = 'foo';
+            $scope.$digest();
+
+            // Assert
+            expect(getInput().val()).toEqual('foo');
+        });
+    });
+
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act


### PR DESCRIPTION
Add an option for determining when the underlying input changes.
This feature is important because it allows developers to know when
the input has changed as well the state of the input at the time of
the change.

Closes #197.