### PR TITLE
fix(tagsInput): fix add-on-paste issue in IE

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -42,7 +42,7 @@
  * @param {expression} onTagRemoving Expression to evaluate that will be invoked before removing a tag. The tag is available as $tag. This method must return either true or false. If false, the tag will not be removed.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
  */
-tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, tiUtil) {
+tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInputConfig, tiUtil) {
     function TagList(options, events, onTagAdding, onTagRemoving) {
         var self = {}, getTagText, setTagText, tagIsValid;
 
@@ -347,7 +347,13 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
                 })
                 .on('input-paste', function(event) {
                     if (options.addOnPaste) {
-                        var data = event.clipboardData.getData('text/plain');
+                        var data;
+                        if(event.clipboardData) {
+                            data = event.clipboardData.getData('text/plain');
+                        }
+                        else {
+                            data = $window.clipboardData.getData('Text');
+                        }
                         var tags = data.split(options.pasteSplitPattern);
                         if (tags.length > 1) {
                             tags.forEach(function(tag) {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -2,18 +2,19 @@
 
 describe('tags-input directive', function() {
     var $compile, $scope, $timeout, $document,
-        isolateScope, element;
+        $window, isolateScope, element;
 
     beforeEach(function() {
         jasmine.addMatchers(customMatchers);
 
         module('ngTagsInput');
 
-        inject(function(_$compile_, _$rootScope_, _$document_, _$timeout_) {
+        inject(function(_$compile_, _$rootScope_, _$document_, _$timeout_, _$window_) {
             $compile = _$compile_;
             $scope = _$rootScope_;
             $document = _$document_;
             $timeout = _$timeout_;
+            $window = _$window_;
         });
     });
 
@@ -650,6 +651,25 @@ describe('tags-input directive', function() {
 
             // Assert
             expect(isolateScope.options.addOnPaste).toBe(false);
+        });
+
+        it('works in IE', function() {
+            // Arrange
+            compile('add-on-paste="true"');
+            $window.clipboardData = eventData.clipboardData;
+            eventData.clipboardData = undefined;
+            $window.clipboardData.getData.and.returnValue('tag1, tag2, tag3');
+
+            // Act
+            var event = jQuery.Event('paste', eventData);
+            getInput().trigger(event);
+
+            // Assert
+            expect($scope.tags).toEqual([
+                { text: 'tag1' },
+                { text: 'tag2' },
+                { text: 'tag3' }
+            ]);
         });
 
         it('splits the pasted text into tags if there is more than one tag and the option is true', function() {


### PR DESCRIPTION
Fix an error when pasting in IE. IE uses window.clipboardData
instead of putting clipboardData on the event itself.

Fixes #325.