### PR TITLE
feat(tagsInput): Add tagItemClass option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -38,6 +38,7 @@
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onInvalidTag Expression to evaluate when a tag is invalid. The invalid tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
+ * @param {string=} [tagItemClass=text] Property to individualize tags by adding an html class to each tag-item.
  */
 tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) {
     function TagList(options, events) {
@@ -152,7 +153,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                 displayProperty: [String, 'text'],
                 allowLeftoverText: [Boolean, false],
                 addFromAutocompleteOnly: [Boolean, false],
-                spellcheck: [Boolean, true]
+                spellcheck: [Boolean, true],
+                tagItemClass: [String, 'text']
             });
 
             $scope.tagList = new TagList($scope.options, $scope.events);
@@ -202,6 +204,16 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
 
             scope.getDisplayText = function(tag) {
                 return safeToString(tag[options.displayProperty]);
+            };
+
+            scope.getTagClass = function(tag) {
+                var tagValue = safeToString(tag[options.tagItemClass]);
+                if (tagValue){
+                    return 'tag-item-' + tagValue
+                        .toLowerCase()
+                        .replace(/\W+/g, '-')
+                        .replace(/([a-z\d])([A-Z])/g, '$1-$2');
+                }
             };
 
             scope.track = function(tag) {

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -1,7 +1,7 @@
 <div class="host" tabindex="-1" ng-click="eventHandlers.host.click()" ti-transclude-append>
   <div class="tags" ng-class="{focused: hasFocus}">
     <ul class="tag-list">
-      <li class="tag-item" ng-repeat="tag in tagList.items track by track(tag)" ng-class="{ selected: tag == tagList.selected }">
+      <li class="tag-item {{ getTagClass(tag) }}" ng-repeat="tag in tagList.items track by track(tag)" ng-class="{ selected: tag == tagList.selected }">
         <span ng-bind="getDisplayText(tag)"></span>
         <a class="remove-button" ng-click="tagList.remove($index)" ng-bind="options.removeTagSymbol"></a>
       </li>

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1189,6 +1189,42 @@ describe('tags-input directive', function() {
 
     });
 
+    describe('tag-item-class option', function() {
+        it('initializes the option to "text"', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.tagItemClass).toBe('text');
+        });
+
+        it('adds an html class to each tagItem', function() {
+            // Arrange
+            $scope.tags = generateTags(1);
+
+            // Act
+            compile();
+
+            // Assert
+            expect(getTag(0)).toHaveClass('tag-item-tag1');
+        });
+
+        it('adds an html class to each tagItem when selecting a different property', function() {
+            // Arrange
+            $scope.tags = [
+                {text: 'tag1', label: 'Customer Service'},
+                {text: 'tag2', label: 'Payment'}
+            ];
+
+            // Act
+            compile('tag-item-class="label"');
+
+            // Assert
+            expect(getTag(0)).toHaveClass('tag-item-customer-service');
+            expect(getTag(1)).toHaveClass('tag-item-payment');
+        });
+    });
+
     describe('allow-leftover-text option', function() {
         it('initializes the option to false', function() {
             // Arrange/Act


### PR DESCRIPTION
Add option to set a property that the tag item will
receive as an HTML class. This feature is important because it
differentiate tags between each other and adds the possibility of
styling tags individually.

Often times is important to style tags differently according to a property of the object.
Example: 
http://cl.ly/423P2p080g1P
