### PR TITLE
Fixes conflicting keyCode for comma

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -116,6 +116,17 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
         return SUPPORTED_INPUT_TYPES.indexOf(type) !== -1;
     }
 
+    /**
+     * validate comma key
+     *
+     * @param e
+     * @returns {boolean}
+     */
+    function validateComma(e) {
+        var originalEvent = e.originalEvent || e;
+        return (e.keyCode !== KEYS.comma) || (e.key || e.char) === ',' || originalEvent.keyIdentifier === 'U+002C';
+    }
+
     return {
         restrict: 'E',
         require: 'ngModel',
@@ -305,7 +316,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
                     addKeys[KEYS.comma] = options.addOnComma;
                     addKeys[KEYS.space] = options.addOnSpace;
 
-                    shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
+                    shouldAdd = !options.addFromAutocompleteOnly && addKeys[key] && validateComma(event);
                     shouldRemove = !shouldAdd && key === KEYS.backspace && scope.newTag.text.length === 0;
 
                     if (shouldAdd) {

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -119,12 +119,20 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
     /**
      * validate comma key
      *
+     * Event properties to verify ','
+     * Chrome: keyIdentifier: "U+002C"
+     * FF: key
+     * IE: char|key
+     * Safari: -
+     *
      * @param e
      * @returns {boolean}
      */
     function validateComma(e) {
         var originalEvent = e.originalEvent || e;
-        return (e.keyCode !== KEYS.comma) || (e.key || e.char) === ',' || originalEvent.keyIdentifier === 'U+002C';
+        var char = e.key || e.char || originalEvent.keyIdentifier;
+        var unsupported = typeof char === 'undefined';
+        return (unsupported || e.keyCode !== KEYS.comma) || char === ',' || char === 'U+002C';
     }
 
     return {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -61,13 +61,13 @@ describe('tags-input directive', function() {
         return element.find('input');
     }
 
-    function newTag(tag, key) {
+    function newTag(tag, key, properties) {
         key = key || KEYS.enter;
 
         for(var i = 0; i < tag.length; i++) {
             sendKeyPress(tag.charCodeAt(i));
         }
-        sendKeyDown(key);
+        sendKeyDown(key, properties);
     }
 
     function sendKeyPress(charCode) {
@@ -465,18 +465,30 @@ describe('tags-input directive', function() {
             compile('add-on-comma="true"');
 
             // Act
-            newTag('foo', KEYS.comma);
+            newTag('foo', KEYS.comma, {key: ','});
 
             // Assert
             expect($scope.tags).toEqual([{ text: 'foo' }]);
         });
+
+        it('does not add a new tag when the < key is pressed and the comma option is true', function() {
+            // Arrange
+            compile('add-on-comma="true"');
+
+            // Act
+            newTag('foo', KEYS.comma, {key: '<'});
+
+            // Assert
+            expect($scope.tags).not.toEqual([{ text: 'foo' }]);
+        });
+
 
         it('does not add a new tag when the space key is pressed and the option is false', function() {
             // Arrange
             compile('add-on-comma="false"');
 
             // Act
-            newTag('foo', KEYS.comma);
+            newTag('foo', KEYS.comma, {key: ','});
 
             // Assert
             expect($scope.tags).toEqual([]);
@@ -1504,16 +1516,29 @@ describe('tags-input directive', function() {
             it('prevents enter, comma and space keys from being propagated when all modifiers are up', function() {
                 // Arrange
                 hotkeys = [KEYS.enter, KEYS.comma, KEYS.space];
+                var keys = ['Enter',',',' '];
 
                 // Act/Assert
-                angular.forEach(hotkeys, function(key) {
+                angular.forEach(hotkeys, function(key,index) {
                     expect(sendKeyDown(key, {
                         shiftKey: false,
                         ctrlKey: false,
                         altKey: false,
-                        metaKey: false
+                        metaKey: false,
+                        key: keys[index]
                     }).isDefaultPrevented()).toBe(true);
                 });
+            });
+
+            it('does not prevent "fake" comma key from being propagated when all modifiers are up', function() {
+                // Act/Assert
+                expect(sendKeyDown(KEYS.comma, {
+                    shiftKey: false,
+                    ctrlKey: false,
+                    altKey: false,
+                    metaKey: false,
+                    key: '<'
+                }).isDefaultPrevented()).not.toBe(true);
             });
 
             it('prevents the backspace key from being propagated when all modifiers are up', function() {


### PR DESCRIPTION
Added additional helper method to validate comma so a new tag won't be created when pressing `<`
(#334)
