### PR TITLE
feat: allow attribute restriction for both tags

### DIFF
--- a/scss/auto-complete.scss
+++ b/scss/auto-complete.scss
@@ -1,46 +1,48 @@
 @import "mixins";
 @import "variables";
 
-tags-input .autocomplete {
-  margin-top: 5px;
-  position: absolute;
-  padding: 5px 0;
-  z-index: $suggestions-z-index;
-  width: $suggestions-width;
-  background-color: $suggestions-bgcolor;
-  border: $suggestions-border;
-  @include box-shadow($suggestions-border-shadow);
+tags-input, [data-tags-input], [tags-input] {
+  .autocomplete {
+    margin-top: 5px;
+    position: absolute;
+    padding: 5px 0;
+    z-index: $suggestions-z-index;
+    width: $suggestions-width;
+    background-color: $suggestions-bgcolor;
+    border: $suggestions-border;
+    @include box-shadow($suggestions-border-shadow);
 
-  .suggestion-list {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-  }
-
-  .suggestion-item {
-    padding: 5px 10px;
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font: $suggestion-font;
-    color: $suggestion-color;
-    background-color: $suggestion-bgcolor;
-
-    &.selected {
-      color: $suggestion-color-selected;
-      background-color: $suggestion-bgcolor-selected;
-
-      em {
-        color: $suggestion-highlight-color-selected;
-        background-color: $suggestion-highlight-bgcolor-selected;
-      }
+    .suggestion-list {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
     }
 
-    em {
-      font: $suggestion-highlight-font;
-      color: $suggestion-highlight-color;
-      background-color: $suggestion-highlight-bgcolor;
+    .suggestion-item {
+      padding: 5px 10px;
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font: $suggestion-font;
+      color: $suggestion-color;
+      background-color: $suggestion-bgcolor;
+
+      &.selected {
+        color: $suggestion-color-selected;
+        background-color: $suggestion-bgcolor-selected;
+
+        em {
+        color: $suggestion-highlight-color-selected;
+        background-color: $suggestion-highlight-bgcolor-selected;
+        }
+      }
+
+      em {
+        font: $suggestion-highlight-font;
+        color: $suggestion-highlight-color;
+        background-color: $suggestion-highlight-bgcolor;
+      }
     }
   }
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,4 +1,4 @@
-tags-input {
+tags-input, div[tags-input], div[data-tags-input] {
   display: block;
 
   *, *:before, *:after {

--- a/scss/tags-input.scss
+++ b/scss/tags-input.scss
@@ -1,7 +1,7 @@
 @import "mixins";
 @import "variables";
 
-tags-input {
+tags-input, [tags-input], [data-tags-input] {
   .tags {
     -moz-appearance: textfield;
     -webkit-appearance: textfield;

--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -107,7 +107,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
     }
 
     return {
-        restrict: 'E',
+        restrict: 'EA',
         require: '^tagsInput',
         scope: { source: '&' },
         templateUrl: 'ngTagsInput/auto-complete.html',

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -117,7 +117,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
     }
 
     return {
-        restrict: 'E',
+        restrict: 'EA',
         require: 'ngModel',
         scope: {
             tags: '=ngModel',


### PR DESCRIPTION
Changes the `E` restriction to `EA` such that ngTagsInput may be used via an attribute (`<div tags-input>`). This allows the production of valid HTML rather than unregistered custom tags/elements, and improves consistency in projects which do not use such custom elements.

Closes #344.