### PR TITLE
fix(style): correct auto-complete <em> style with minifying

### DIFF
--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -35,7 +35,7 @@ $suggestion-bgcolor:                    #fff;
 $suggestion-color-selected:             #fff;
 $suggestion-bgcolor-selected:           #0097cf;
 
-$suggestion-highlight-font:             normal bold $suggestion-font;
+$suggestion-highlight-font:             bold $suggestion-font;
 $suggestion-highlight-color:            $suggestion-color;
 $suggestion-highlight-bgcolor:          $suggestion-bgcolor;
 $suggestion-highlight-color-selected:   $suggestion-color-selected;


### PR DESCRIPTION
In development I have no problem with that property:

```
tags-input .autocomplete .suggestion-item em {
    font: normal bold 16px "Helvetica Neue",Helvetica,Arial,sans-serif;
}
````

But when I build and hence minify my css this one become:

```
tags-input .autocomplete .suggestion-item em {
    font: 400 bold 16px "Helvetica Neue",Helvetica,Arial,sans-serif;
}
````

Which result in an invalid property value for the browser so the auto-complete is not well styled.
I suggest to remove the `normal` precision for the font-style as it's the default one and it's solve the problem.