### PR TITLE
feat(tagsInput): Add trackBy option for ng-repeat

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -10,6 +10,7 @@
  *
  * @param {string} ngModel Assignable angular expression to data-bind to.
  * @param {string=} [displayProperty=text] Property to be rendered as the tag label.
+ * @param {string=} [trackBy=null] Property to be used in the ng-repeat track by option.
  * @param {string=} [type=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
  * @param {number=} tabindex Tab order of the control.
  * @param {string=} [placeholder=Add a tag] Placeholder text for the control.
@@ -150,6 +151,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
                 minTags: [Number, 0],
                 maxTags: [Number, MAX_SAFE_INTEGER],
                 displayProperty: [String, 'text'],
+                trackBy: [String, null],
                 allowLeftoverText: [Boolean, false],
                 addFromAutocompleteOnly: [Boolean, false],
                 spellcheck: [Boolean, true]
@@ -205,7 +207,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
             };
 
             scope.track = function(tag) {
-                return tag[options.displayProperty];
+                return tag[options.trackBy || options.displayProperty];
             };
 
             scope.$watch('tags', function(value) {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1,5 +1,4 @@
 'use strict';
-
 describe('tags-input directive', function() {
     var $compile, $scope, $timeout, $document,
         isolateScope, element;
@@ -1198,6 +1197,57 @@ describe('tags-input directive', function() {
                 { label: 'Item1' },
                 { label: 'Item2' },
                 { label: 'Item3' }
+            ]);
+        });
+
+    });
+
+    describe('track-by option', function() {
+        it('defaults to null', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.trackBy).toBe(null);
+        });
+
+        it('throws an ng-repeat error if there are duplicates and trackBy is not specified', function() {
+            var error;
+            // Arrange
+            $scope.tags = [
+                { id: 1, text: 'Tag1' },
+                { id: 2, text: 'Tag1' },
+                { id: 3, text: 'Tag1' },
+            ];
+
+            // Act
+            try {
+                compile();
+            } catch (err) {
+                error = err;
+            }
+
+            // Assert
+            expect(error).toBeTruthy();
+            expect(error.message.indexOf('[ngRepeat:dupes]')).toBe(0);
+        });
+
+        it('works if trackBy is set', function() {
+            // Arrange
+            $scope.tags = [
+                { id: 1, text: 'Tag1' },
+                { id: 2, text: 'Tag1' },
+                { id: 3, text: 'Tag1' },
+            ];
+
+            // Act
+            compile('track-by="id"');
+
+            // Assert
+            expect($scope.tags).toEqual([
+                { id: 1, text: 'Tag1' },
+                { id: 2, text: 'Tag1' },
+                { id: 3, text: 'Tag1' }
             ]);
         });
 


### PR DESCRIPTION
Previously if the displayProperty contained any duplicate values, ng-repeat duplicate errors would be thrown. This commit adds an optional track-by attribute that can be used to resolve this potential error.

Closes #378