### PR TITLE
feat(autocomplete): Custom template support for autocomplete

### DIFF
--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -1,21 +1,21 @@
 'use strict';
 
 describe('autoComplete directive', function() {
-    var $compile, $scope, $q, $timeout,
+    var $compile, $scope, $q, $timeout,$templateCache,
         parentCtrl, element, isolateScope, suggestionList, deferred, tagsInput, eventHandlers;
 
     beforeEach(function() {
+
         jasmine.addMatchers(customMatchers);
 
         module('ngTagsInput');
-
-        inject(function($rootScope, _$compile_, _$q_, _$timeout_) {
+        inject(function($rootScope, _$compile_, _$q_, _$timeout_,_$templateCache_){
+            $templateCache = _$templateCache_;
             $scope = $rootScope;
             $compile = _$compile_;
             $q = _$q_;
             $timeout = _$timeout_;
         });
-
         deferred = $q.defer();
         eventHandlers = {
             call: function(name, args) {
@@ -26,6 +26,9 @@ describe('autoComplete directive', function() {
         };
         $scope.loadItems = jasmine.createSpy().and.returnValue(deferred.promise);
 
+        $templateCache.put('custom_template.html',
+            '{{text}} - {{author}}'
+        );
         compile();
     });
 
@@ -1087,5 +1090,43 @@ describe('autoComplete directive', function() {
             expect(getSuggestion(2)).not.toHaveClass('selected');
 
         });
+    });
+    describe('custom template feature', function() {
+        it('initializes templateHtml to undefined', function() {
+            compile();
+            expect(isolateScope.options.templateHtml).toBe(undefined);
+        });
+        it('initializes templateHtmlUrl to undefined', function() {
+            compile();
+            expect(isolateScope.options.templateHtmlUrl).toBe(undefined);
+        });
+        it('uses default template for suggestion if option templateHtmlUrl is not specified', function() {
+            compile();
+            loadSuggestions({
+                data: [
+                    { text: 'Superman', author:'Jerry Siegel' },
+                    { text: 'Spiderman', author:'Stan Lee' }
+                ]
+            });
+            expect(getSuggestionText(0)).toBe('Superman');
+            expect(getSuggestionText(1)).toBe('Spiderman');
+        });
+        it('uses custom template for suggestion if option templateHtmlUrl is specified', function() {
+            compile('template-html-url="custom_template.html"');
+            expect(isolateScope.options.templateHtmlUrl).toBe('custom_template.html');
+            expect(isolateScope.options.templateHtml).toBe('{{text}} - {{author}}');
+            loadSuggestions({
+                data: [
+                    { text: 'Superman', author:'Jerry Siegel' },
+                    { text: 'Spiderman', author:'Stan Lee' }
+                ]
+            });
+            expect(getSuggestionText(0)).toBe('Superman - Jerry Siegel');
+            expect(getSuggestionText(1)).toBe('Spiderman - Stan Lee');
+        });
+
+        
+
+      
     });
 });

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -43,12 +43,22 @@
     }
   </style>
 </head>
+<script type="text/ng-template" id="custome_template.html">
+ {{text}} - {{author}}
+</script>
 <body ng-controller="Ctrl">
+
     <p></p>
     <tags-input ng-model="tags" add-on-blur="false" ng-focus="focus()" ng-blur="blur()" add-on-paste="true" paste-split-pattern="[,;|]" spellcheck="false">
         <auto-complete source="loadItems($query)" load-on-down-arrow="true"></auto-complete>
     </tags-input>
     <p></p>
+      <span class="input-group-addon">Custome Autocomplete</span>
+      <p></p>
+     <tags-input ng-model="tags" add-on-blur="false" ng-focus="focus()" ng-blur="blur()" add-on-paste="true" paste-split-pattern="[,;|]" spellcheck="false">
+        <auto-complete template-html-url="custome_template.html" source="loadItems($query)" load-on-down-arrow="true"></auto-complete>
+    </tags-input>
+     <p></p>
     <div class="input-group" style="width: 600px">
         <span class="input-group-addon">@</span>
         <tags-input ng-model="tags">
@@ -96,15 +106,15 @@
     angular.module('app', ['ngTagsInput'])
         .controller('Ctrl', function($scope, $q) {
             var superheroes = [
-              { text: 'Batman <bruce@wayne.com>' },
-              { text: 'Superman' },
-              { text: 'Flash' },
-              { text: 'Iron Man' },
-              { text: 'Hulk' },
-              { text: 'Wolverine' },
-              { text: 'Green Lantern' },
-              { text: 'Green Arrow' },
-              { text: 'Spiderman'}
+              { text: 'Batman <bruce@wayne.com>', author:'Bob Kane' },
+              { text: 'Superman', author:'Jerry Siegel' },
+              { text: 'Flash', author:'Gardner Fox' },
+              { text: 'Iron Man', author:'Stan Lee' },
+              { text: 'Hulk', author:'Stan Lee' },
+              { text: 'Wolverine', author:'Len Wein' },
+              { text: 'Green Lantern', author:'Bill Finger' },
+              { text: 'Green Arrow', author:'George Papp' },
+              { text: 'Spiderman', author:'Stan Lee'}
             ];
 
             $scope.tags = [{ text: 'Batman' }, { text: 'Superman' }, { text:'Flash' }];


### PR DESCRIPTION
Add support to render the suggestion for autocomplete using custom template. Add a new option for directive auto-complete, template-html-url, this is the url to load template html. If the option is not defined, the suggestion is using the default html. Otherwise, it is using the custom html. Custom html might look like  “{{text}} - {{author}}”. Template could be defined in html by using “<script type="text/ng-template" id="custome_template.html"></script>”

Issue #99