### PR TITLE
Only using ng model for sets2

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -290,7 +290,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
                 .on('tag-added tag-removed', function() {
                     // Sets the element to its dirty state
                     // In Angular 1.3 this will be replaced with $setDirty.
-                    ngModelCtrl.$setViewValue(scope.tags);
+                    scope.tags = tagList.items;
+                    ngModelCtrl.$setViewValue(tagList.items);
                 })
                 .on('invalid-tag', function() {
                     scope.newTag.invalid = true;

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -206,8 +206,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
                 setElementValidity;
 
             setElementValidity = function() {
-                ngModelCtrl.$setValidity('maxTags', scope.tags.length <= options.maxTags);
-                ngModelCtrl.$setValidity('minTags', scope.tags.length >= options.minTags);
+                var tagsLength = (scope.tags && scope.tags.length) || 0;
+                ngModelCtrl.$setValidity('maxTags', tagsLength <= options.maxTags);
+                ngModelCtrl.$setValidity('minTags', tagsLength >= options.minTags);
                 ngModelCtrl.$setValidity('leftoverText', scope.hasFocus || options.allowLeftoverText ? true : !scope.newTag.text);
             };
 
@@ -229,8 +230,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig, 
             };
 
             scope.$watch('tags', function(value) {
-                scope.tags = tiUtil.makeObjectArray(value, options.displayProperty);
-                tagList.items = scope.tags;
+                tagList.items = tiUtil.makeObjectArray(value, options.displayProperty);
             });
 
             scope.$watch('tags.length', function() {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -14,6 +14,8 @@ describe('tags-input directive', function() {
             $scope = _$rootScope_;
             $document = _$document_;
             $timeout = _$timeout_;
+
+            $scope.tags = [];
         });
     });
 
@@ -101,13 +103,6 @@ describe('tags-input directive', function() {
     }
 
     describe('basic features', function() {
-        it('initializes the model as an empty array', function() {
-            // Arrange/Act
-            compile();
-
-            // Assert
-            expect($scope.tags).toEqual([]);
-        });
 
         it('renders the correct number of tags', function() {
             // Arrange
@@ -160,7 +155,6 @@ describe('tags-input directive', function() {
             newTag(' Tag2');
             newTag(' Tag3 ');
 
-            // Assert
             expect($scope.tags).toEqual([
                 { text: 'Tag1' },
                 { text: 'Tag2' },


### PR DESCRIPTION
Not setting tags explicitly as that circumvents ng-model and can create invalid models on parent, especially when model hasn't been loaded yet (scope.tags === undefined). Removed test for testing just that and defaulted .tags to be [] in tests for them to work the way they were written. Also defaulted to updating BOTH through ngModel and direct 2-way angular binding on tags, since otherwise a lot of tests would have broken.

Can break code that relies on their model being initialized indirectly by tagsInput. Closes #320 