### PR TITLE
Adds tab-key functionality to the tab close button.

### DIFF
--- a/templates/tag-item.html
+++ b/templates/tag-item.html
@@ -1,2 +1,4 @@
-<span ng-bind="$getDisplayText()"></span>
-<a class="remove-button" ng-click="$removeTag()" ng-bind="$$removeTagSymbol"></a>
+<form>
+  <span ng-bind="$getDisplayText()"></span>
+  <button class="remove-button" role="submit" ng-click="$removeTag()" ng-bind="$$removeTagSymbol"></button>
+</form>

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -51,11 +51,11 @@ describe('tags-input directive', function() {
     }
 
     function getTagText(index) {
-        return getTag(index).find('ti-tag-item > ng-include > span').html();
+        return getTag(index).find('ti-tag-item > ng-include > form > span').html();
     }
 
     function getRemoveButton(index) {
-        return getTag(index).find('ti-tag-item > ng-include > a').first();
+        return getTag(index).find('ti-tag-item > ng-include > form > button').first();
     }
 
     function getInput() {


### PR DESCRIPTION
IMO its limiting to force the user to interact with their mouse. By tweaking the markup slightly we get the ability to tab through the individual tabs for free. Now you can insert tabs and remove them like a keyboard boss.

Also, I changed you're anchor tags to buttons to be more semantic. Cheers and thanks for the great directive!