### PR TITLE
feat(tagsInput): Add support for selecting tags on click

### DIFF
--- a/src/tag-item.js
+++ b/src/tag-item.js
@@ -27,6 +27,9 @@ tagsInput.directive('tiTagItem', function(tiUtil) {
             scope.$removeTag = function() {
                 tagsInput.removeTag(scope.$index);
             };
+            scope.$selectTag = function() {
+                tagsInput.selectTag(scope.$index);
+            };
 
             scope.$watch('$parent.$index', function(value) {
                 scope.$index = value;

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -228,6 +228,12 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                             return;
                         }
                         $scope.tagList.remove(index);
+                    },
+                    selectTag: function(index) {
+                        if ($scope.disabled) {
+                            return;
+                        }
+                        $scope.tagList.select(index);
                     }
                 };
             };

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1589,6 +1589,7 @@ describe('tags-input directive', function() {
             var scope = getTagScope(0);
             expect(scope.$getDisplayText).not.toBeUndefined();
             expect(scope.$removeTag).not.toBeUndefined();
+            expect(scope.$selectTag).not.toBeUndefined();
         });
     });
 

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -27,13 +27,15 @@
       <auto-complete source="loadItems($query)" min-length="1" load-on-down-arrow="true" load-on-focus="true" load-on-empty="true" template="autocomplete-template"></auto-complete>
   </tags-input>
 
-  <script type="text/ng-template" id="tag-template">
-    <div style="float: left;">
-      <img ng-src="{{data.picture}}" width="20" height="20" style="vertical-align: middle"/>
-    </div>
-    <div style="float: left; padding-left: 2px">
-      <span>{{$getDisplayText()}}</span>
-      <a class="remove-button" ng-click="$removeTag()">&times;</a>
+  <script type="text/ng-template" id="tag-template" >
+    <div ng-click="$selectTag()">
+      <div style="float: left;">
+        <img ng-src="{{data.picture}}"  width="20" height="20" style="vertical-align: middle"/>
+      </div>
+      <div style="float: left; padding-left: 2px">
+        <span>{{$getDisplayText()}}</span>
+        <a class="remove-button" ng-click="$removeTag()">&times;</a>
+      </div>
     </div>
   </script>
 


### PR DESCRIPTION
Add the possibility for the user to click in a tag to select it, so it can be removed when clicking backspace. Adds a function called $selectTag() to the item template that can be used in a custom template. It uses the same logic as $removeTag().