### PR TITLE
feat(tagsInput): Add support for autocomplete option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -15,6 +15,7 @@
  * @param {string=} [type=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
  * @param {number=} tabindex Tab order of the control.
  * @param {string=} [placeholder=Add a tag] Placeholder text for the control.
+ * @param {string=} [autocomplete=on] Autocomplete option.
  * @param {number=} [minLength=3] Minimum length for a new tag.
  * @param {number=} [maxLength=MAX_SAFE_INTEGER] Maximum length allowed for a new tag.
  * @param {number=} [minTags=0] Sets minTags validation error key if the number of tags added is less than minTags.
@@ -166,6 +167,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 template: [String, 'ngTagsInput/tag-item.html'],
                 type: [String, 'text', validateType],
                 placeholder: [String, 'Add a tag'],
+                autoComplete: [String, 'on'],
                 tabindex: [Number, null],
                 removeTagSymbol: [String, String.fromCharCode(215)],
                 replaceSpacesWithDashes: [Boolean, true],

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -832,6 +832,16 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('autocomplete option', function() {
+        it('sets the input\'s autocomplete option', function() {
+            // Arrange/Act
+            compile('autocomplete="off"');
+
+            // Assert
+            expect(getInput().attr('autocomplete')).toBe('off');
+        });
+    });
+
     describe('remove-tag-symbol option', function() {
         it('sets the remove button text', function() {
             // Arrange/Act


### PR DESCRIPTION
Add a autocomplete option that is passed to the input field, so we are able to disable it if we need. Set to on by default.