### PR TITLE
feat(tagsInput): Add support for adding extra attributes to the .tags…

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -44,8 +44,11 @@
  *    is available as $tag. This method must return either true or false. If false, the tag will not be removed.
  * @param {expression=} [onTagRemoved=NA] Expression to evaluate upon removing an existing tag. The removed tag is
  *    available as $tag.
+ * @param {string=} [tagsExtraAttrs=NA] Ads extra attributes to the .tags element in the template, useful to add
+ *    extra directives or any other HTML tag needed to that element. The value should be an object where the keys are the
+ *    attribute and the value the attribute value. For example tags-extra-attrs="{myelement: 'myvalue'}".
  */
-tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInputConfig, tiUtil) {
+tagsInput.directive('tagsInput', function($timeout, $document, $parse, $window, tagsInputConfig, tiUtil) {
     function TagList(options, events, onTagAdding, onTagRemoving) {
         var self = {}, getTagText, setTagText, tagIsValid;
 
@@ -166,6 +169,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 template: [String, 'ngTagsInput/tag-item.html'],
                 type: [String, 'text', validateType],
                 placeholder: [String, 'Add a tag'],
+                tagsExtraAttrs: [String, null],
                 tabindex: [Number, null],
                 removeTagSymbol: [String, String.fromCharCode(215)],
                 replaceSpacesWithDashes: [Boolean, true],
@@ -232,6 +236,13 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 };
             };
         },
+        compile: function(element, attrs) {
+            if (attrs.tagsExtraAttrs) {
+                angular.element(element[0].getElementsByClassName('tags')).attr($parse(attrs.tagsExtraAttrs)());
+            }
+            return this.link;
+        },
+
         link: function(scope, element, attrs, ngModelCtrl) {
             var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace, KEYS.delete, KEYS.left, KEYS.right],
                 tagList = scope.tagList,

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -458,6 +458,24 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('tagsExtraAttrs option', function() {
+        it('sets the tags extra attributes', function() {
+            // Arrange/Act
+            compile('tags-extra-attrs="{customatr: \'yes\'}"');
+
+            // Assert
+            expect(element.find('.tags').attr('customatr')).toBe('yes');
+        });
+
+        it('initializes the option to null', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.tagsExtraAttrs).toBeNull();
+        });
+    });
+
     describe('add-on-enter option', function() {
         it('adds a new tag when the enter key is pressed and the option is true', function() {
             // Arrange


### PR DESCRIPTION
… html element

Ads extra attributes to the .tags element in the template, useful to add extra directives or any other HTML tag needed to that element. The value should be an object where the keys are the attribute and the value the attribute value. For example tags-extra-attrs="{myelement: 'myvalue'}". Defaults to null.