### PR TITLE
Denoted allowedTagsPattern ad RegExp and added statefulness warning

### DIFF
--- a/_includes/api/tagsInput.html
+++ b/_includes/api/tagsInput.html
@@ -176,8 +176,8 @@
         </tr>
         <tr>
           <td>allowedTagsPattern</td>
-          <td><span class="label type type-string">string</span></td>
-          <td>Regular expression that determines whether a new tag is valid.</td>
+          <td><span class="label type type-regexp">RegExp</span></td>
+          <td>Regular expression that determines whether a new tag is valid. Please note that using <em>global</em> flag will make the regular expression stateful.</td>
           <td>.+</td>
         </tr>
         <tr>

--- a/css/styles.css
+++ b/css/styles.css
@@ -88,6 +88,10 @@ h3 {
     background-color: #999;
 }
 
+.type-regexp {
+    background-color: #5a54bd;
+}
+
 .methods {
     padding-left: 0;
 }


### PR DESCRIPTION
Tackling with this took me time twice: one time several days ago when I needed to set the validation expression as a string until I read it's supposed to be a RegExp. Then it took me some time for the second time, when I was resolving a bug" tag is only created after 2nd keydown but only for 2+ tag committed.

FYI: Color chosen for `.type-regexp` is the same as on https://docs.angularjs.org/ (I only converted it to hex to match the others)