### PR TITLE
feat(tagsInput): add option to set autofocus

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -15,6 +15,7 @@
  * @param {string=} [type=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
  * @param {number=} tabindex Tab order of the control.
  * @param {string=} [placeholder=Add a tag] Placeholder text for the control.
+ * @param {boolean=} [autofocus=false] Autofocus property.
  * @param {number=} [minLength=3] Minimum length for a new tag.
  * @param {number=} [maxLength=MAX_SAFE_INTEGER] Maximum length allowed for a new tag.
  * @param {number=} [minTags=0] Sets minTags validation error key if the number of tags added is less than minTags.
@@ -166,6 +167,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 template: [String, 'ngTagsInput/tag-item.html'],
                 type: [String, 'text', validateType],
                 placeholder: [String, 'Add a tag'],
+                autofocus: [Boolean, false],
                 tabindex: [Number, null],
                 removeTagSymbol: [String, String.fromCharCode(215)],
                 replaceSpacesWithDashes: [Boolean, true],
@@ -285,6 +287,10 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
             attrs.$observe('disabled', function(value) {
                 scope.disabled = value;
             });
+
+            if (options.autofocus) {
+                input[0].autofocus = true;
+            }
 
             scope.eventHandlers = {
                 input: {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -458,6 +458,24 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('tabindex option', function() {
+        it('sets the input field autofocus', function() {
+            // Arrange/Act
+            compile('autofocus="true"');
+
+            // Assert
+            expect(getInput().attr('autofocus')).toBe('autofocus');
+        });
+
+        it('initializes the option to null', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.autofocus).toBe(false);
+        });
+    });
+
     describe('add-on-enter option', function() {
         it('adds a new tag when the enter key is pressed and the option is true', function() {
             // Arrange


### PR DESCRIPTION
Ads an autofocus option that sets the autofocus value for the input tag. Defaults to false.