### PR TITLE
fix(tagsInput): remove empty tag list

### DIFF
--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -1,6 +1,6 @@
 <div class="host" tabindex="-1" ng-click="eventHandlers.host.click()" ti-transclude-append>
   <div class="tags" ng-class="{focused: hasFocus}">
-    <ul class="tag-list">
+    <ul class="tag-list" ng-if="tagList.items.length > 0">
       <li class="tag-item"
           ng-repeat="tag in tagList.items track by track(tag)"
           ng-class="{ selected: tag == tagList.selected }">

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -282,6 +282,24 @@ describe('tags-input directive', function() {
             expect(isolateScope.events.trigger).toHaveBeenCalledWith('input-change', '');
         });
 
+        it('doesn\'t show the tag-list element when the tag list is empty', function() {
+            // Arrange
+            compile();
+
+            // Assert
+            expect(element.find('.tag-list').length).toBe(0);
+        });
+
+        it('shows the tag-list element when the tag list is not empty', function() {
+            // Arrange
+            compile();
+            // Act
+            newTag('foo');
+
+            // Assert
+            expect(element.find('.tag-list').length).toBe(1);
+        });
+
         it('converts an array of strings into an array of objects', function() {
             // Arrange
             $scope.tags = ['Item1', 'Item2', 'Item3'];


### PR DESCRIPTION
Removes the ul.tag-list element when the tag list is empty. Having an empty ul causes artifacts in Chrome when doing animations.