### PR TITLE
fix(tagsInput): observe placeholder value update

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -286,6 +286,12 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 scope.disabled = value;
             });
 
+            attrs.$observe('placeholder', function(value) {
+                if (value) {
+                    options.placeholder = value;
+                }
+            });
+
             scope.eventHandlers = {
                 input: {
                     change: function(text) {


### PR DESCRIPTION
Update the placeholder value when the interpolated value changes. I noticed this works in the demo page, but in my implementation which is a bit more complex it doesn't, and the observe is needed.