### PR TITLE
fix(tagsInput): Avoid duplicated tag-added event

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -333,11 +333,11 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
             };
 
             events
-                .on('tag-added', scope.onTagAdded)
                 .on('invalid-tag', scope.onInvalidTag)
                 .on('tag-removed', scope.onTagRemoved)
-                .on('tag-added', function() {
+                .on('tag-added', function(tag) {
                     scope.newTag.setText('');
+                    scope.onTagAdded(tag);
                 })
                 .on('tag-added tag-removed', function() {
                     scope.tags = tagList.items;


### PR DESCRIPTION
A duplicated tag-added event can cause issues with some configurations when the on-tags-added callback is set.