### PR TITLE
feat(tagsInput): add option to allow/disallow adding tags when max is reached

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -47,6 +47,8 @@
  * @param {expression=} [onTagRemoved=NA] Expression to evaluate upon removing an existing tag. The removed tag is
  *    available as $tag.
  * @param {expression=} [onTagClicked=NA] Expression to evaluate upon clicking an existing tag. The clicked tag is available as $tag.
+ * @param {boolean=} [allowTagsPastMax=true] Flag indicating if the directive will allow tags to be created by the user when
+ *    the maxTags number has been reached
  */
 tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInputConfig, tiUtil) {
     function TagList(options, events, onTagAdding, onTagRemoving) {
@@ -66,6 +68,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
             return tagText &&
                    tagText.length >= options.minLength &&
                    tagText.length <= options.maxLength &&
+                   (options.allowTagsPastMax || self.items.length < options.maxTags) &&
                    options.allowedTagsPattern.test(tagText) &&
                    !tiUtil.findInObjectArray(self.items, tag, options.keyProperty || options.displayProperty) &&
                    onTagAdding({ $tag: tag });
@@ -190,7 +193,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 keyProperty: [String, ''],
                 allowLeftoverText: [Boolean, false],
                 addFromAutocompleteOnly: [Boolean, false],
-                spellcheck: [Boolean, true]
+                spellcheck: [Boolean, true],
+                allowTagsPastMax: [Boolean, true]
             });
 
             $scope.tagList = new TagList($scope.options, $scope.events,

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1260,6 +1260,42 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('allow-tags-past-max', function() {
+        it('initializes the option to true', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.allowTagsPastMax).toBe(true);
+        });
+
+        it('allows the creation of tags even when maxTags is reached and the option is set to true', function() {
+            // Arrange
+            compileWithForm('max-tags="2"', 'allow-tags-past-max="true"');
+
+            // Act
+            newTag('Tag1');
+            newTag('Tag2');
+            newTag('Tag3');
+
+            // Assert
+            expect($scope.tags.length).toBe(3);
+        });
+
+        it('does not allow the creation of tags when maxTags is reached and the option is set to false', function() {
+            // Arrange
+            compileWithForm('max-tags="2"', 'allow-tags-past-max="false"');
+
+            // Act
+            newTag('Tag1');
+            newTag('Tag2');
+            newTag('Tag3');
+
+            // Assert
+            expect($scope.tags.length).toBe(2);
+        });
+    });
+
     describe('display-property option', function() {
         it('initializes the option to "text"', function() {
             // Arrange/Act


### PR DESCRIPTION
Hello,

Currently the directive allows the addition of tags even when the max number is reached that is because it shows the directive as being in error.

This feature will not allow the addition of tags when the directive parameter allowTagsPastMax is set to false. The user will still be able to type except that when "enter" or any other add key is pressed the tag will not be added to the tags list.
