### PR TITLE
Added option to disable select tag on backspace

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -190,7 +190,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 keyProperty: [String, ''],
                 allowLeftoverText: [Boolean, false],
                 addFromAutocompleteOnly: [Boolean, false],
-                spellcheck: [Boolean, true]
+                spellcheck: [Boolean, true],
+                selectOnBackspace: [Boolean, true]
             });
 
             $scope.tagList = new TagList($scope.options, $scope.events,
@@ -398,7 +399,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                     shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
                     shouldRemove = (key === KEYS.backspace || key === KEYS.delete) && tagList.selected;
                     shouldEditLastTag = key === KEYS.backspace && scope.newTag.text().length === 0 && options.enableEditingLastTag;
-                    shouldSelect = (key === KEYS.backspace || key === KEYS.left || key === KEYS.right) && scope.newTag.text().length === 0 && !options.enableEditingLastTag;
+                    shouldSelect = (key === KEYS.backspace || key === KEYS.left || key === KEYS.right) && scope.newTag.text().length === 0 && !options.enableEditingLastTag && options.selectOnBackspace;
 
                     if (shouldAdd) {
                         tagList.addText(scope.newTag.text());


### PR DESCRIPTION
Added option to disable select tag on backspace (selectOnBackspace defaults to true).  This is for when users have tags outside of input field and it's unintuitive to select and delete these tags that are visually separated.