### PR TITLE
fix(tagsInput): Rename tabindex to avoid tab conflicts

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -15,7 +15,7 @@
  * @param {string=} [displayProperty=text] Property to be rendered as the tag label.
  * @param {string=} [type=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
  * @param {string} [text=NA] Assignable Angular expression for data-binding to the element's text.
- * @param {number=} tabindex Tab order of the control.
+ * @param {number=} inputTabindex Tab order of the control.
  * @param {string=} [placeholder=Add a tag] Placeholder text for the control.
  * @param {number=} [minLength=3] Minimum length for a new tag.
  * @param {number=} [maxLength=MAX_SAFE_INTEGER] Maximum length allowed for a new tag.
@@ -171,7 +171,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 template: [String, 'ngTagsInput/tag-item.html'],
                 type: [String, 'text', validateType],
                 placeholder: [String, 'Add a tag'],
-                tabindex: [Number, null],
+                inputTabindex: [Number, null],
                 removeTagSymbol: [String, String.fromCharCode(215)],
                 replaceSpacesWithDashes: [Boolean, true],
                 minLength: [Number, 3],

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -19,7 +19,7 @@
            ng-trim="false"
            ng-class="{'invalid-tag': newTag.invalid}"
            ng-disabled="disabled"
-           ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex, spellcheck: options.spellcheck}"
+           ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.inputTabindex, spellcheck: options.spellcheck}"
            ti-autosize>
   </div>
 </div>

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -470,7 +470,7 @@ describe('tags-input directive', function() {
     describe('tabindex option', function() {
         it('sets the input field tab index', function() {
             // Arrange/Act
-            compile('tabindex="1"');
+            compile('input-tabindex="1"');
 
             // Assert
             expect(getInput().attr('tabindex')).toBe('1');
@@ -481,7 +481,7 @@ describe('tags-input directive', function() {
             compile();
 
             // Assert
-            expect(isolateScope.options.tabindex).toBeNull();
+            expect(isolateScope.options.inputTabindex).toBeNull();
         });
     });
 


### PR DESCRIPTION
Rename tabindex option to input-tabindex, so the tags-input tabindex is not taken into account in the tab navigation, and only the tabindex in the input element