### PR TITLE
feat(autocomplete): Add filterResults option

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -27,8 +27,10 @@
  *    gains focus. The current input value is available as $query.
  * @param {boolean=} [selectFirstMatch=true] Flag indicating that the first match will be automatically selected once
  *    the suggestion list is shown.
+ * @param {boolean=} [filterResults=false] Flag indicating that the suggestion list will be filtered to only show
+ *    matching results.
  */
-tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil) {
+tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil, $filter) {
     function SuggestionList(loadFn, options, events) {
         var self = {}, getDifference, lastPromise, getTagId;
 
@@ -78,6 +80,13 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 }
 
                 items = tiUtil.makeObjectArray(items.data || items, getTagId());
+
+                if (options.filterResults) {
+                    var obj = {};
+                    obj[getTagId()] = query;
+                    items = $filter('filter')(items, obj);
+                }
+
                 items = getDifference(items, tags);
                 self.items = items.slice(0, options.maxResultsToShow);
 
@@ -147,7 +156,8 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 loadOnEmpty: [Boolean, false],
                 loadOnFocus: [Boolean, false],
                 selectFirstMatch: [Boolean, true],
-                displayProperty: [String, '']
+                displayProperty: [String, ''],
+                filterResults: [Boolean, false]
             });
 
             $scope.suggestionList = new SuggestionList($scope.source, $scope.options, $scope.events);

--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -1302,4 +1302,31 @@ describe('autoComplete directive', function() {
             });
         });
     });
+
+    describe('filter-results option', function() {
+        it('initializes the option to false', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.filterResults).toBe(false);
+        });
+
+        it('filters results to show only items matching input', function() {
+            // Arrange
+            compile('filter-results=true');
+
+            // Act
+            loadSuggestions([
+                { text: 'abc' },
+                { text: 'ABC' },
+                { text: 'xyz' }
+            ], 'a');
+
+            // Assert
+            expect(getSuggestions().length).toBe(2);
+            expect(getSuggestionText(0)).toBe('<em>a</em>bc');
+            expect(getSuggestionText(1)).toBe('<em>A</em>BC');
+        });
+    });
 });


### PR DESCRIPTION
Add an option for the user to set so that the suggestion list will
be filtered to only show the suggestions that match the typed input.