### PR TITLE
feat(autocomplete): Add sortResults and sortReverse options

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -27,8 +27,10 @@
  *    gains focus. The current input value is available as $query.
  * @param {boolean=} [selectFirstMatch=true] Flag indicating that the first match will be automatically selected once
  *    the suggestion list is shown.
+ * @param {boolean=} [sortResults=false] Flag indicating that the suggestion list will be sorted.
+ * @param {boolean=} [sortReverse=false] Flag indicating that the suggestion list will be sorted in reverse order.
  */
-tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil) {
+tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil, $filter) {
     function SuggestionList(loadFn, options, events) {
         var self = {}, getDifference, lastPromise, getTagId;
 
@@ -78,6 +80,11 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 }
 
                 items = tiUtil.makeObjectArray(items.data || items, getTagId());
+
+                if (options.sortResults) {
+                    items = $filter('orderBy')(items, getTagId(), options.sortReverse);
+                }
+
                 items = getDifference(items, tags);
                 self.items = items.slice(0, options.maxResultsToShow);
 
@@ -147,7 +154,9 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 loadOnEmpty: [Boolean, false],
                 loadOnFocus: [Boolean, false],
                 selectFirstMatch: [Boolean, true],
-                displayProperty: [String, '']
+                displayProperty: [String, ''],
+                sortResults: [Boolean, false],
+                sortReverse: [Boolean, false]
             });
 
             $scope.suggestionList = new SuggestionList($scope.source, $scope.options, $scope.events);

--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -1302,4 +1302,60 @@ describe('autoComplete directive', function() {
             });
         });
     });
+
+    describe('sort-results option', function() {
+        it('initializes the option to false', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.sortResults).toBe(false);
+        });
+
+        it('sorts results in ascending order', function() {
+            // Arrange
+            compile('sort-results=true');
+
+            // Act
+            loadSuggestions([
+                { text: 'Item2' },
+                { text: 'Item3' },
+                { text: 'Item1' }
+            ]);
+
+            // Assert
+            expect(getSuggestions().length).toBe(3);
+            expect(getSuggestionText(0)).toBe('Item1');
+            expect(getSuggestionText(1)).toBe('Item2');
+            expect(getSuggestionText(2)).toBe('Item3');
+        });
+    });
+
+    describe('sort-reverse option', function() {
+        it('initializes the option to false', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.sortReverse).toBe(false);
+        });
+
+        it('sorts results in descending order', function() {
+            // Arrange
+            compile('sort-results=true', 'sort-reverse=true');
+
+            // Act
+            loadSuggestions([
+                { text: 'Item2' },
+                { text: 'Item3' },
+                { text: 'Item1' }
+            ]);
+
+            // Assert
+            expect(getSuggestions().length).toBe(3);
+            expect(getSuggestionText(0)).toBe('Item3');
+            expect(getSuggestionText(1)).toBe('Item2');
+            expect(getSuggestionText(2)).toBe('Item1');
+        });
+    });
 });


### PR DESCRIPTION
Add an option for the user to set that the suggestion list will be
sorted (ascending). Add an additional option for the user to set to
reverse the sort order (descending).