### PR TITLE
a11y improvements: adding aria-label and id to tag input

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -170,6 +170,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 template: [String, 'ngTagsInput/tag-item.html'],
                 type: [String, 'text', validateType],
                 placeholder: [String, 'Add a tag'],
+                id:[String, ''],
                 tabindex: [Number, null],
                 removeTagSymbol: [String, String.fromCharCode(215)],
                 replaceSpacesWithDashes: [Boolean, true],

--- a/templates/tag-item.html
+++ b/templates/tag-item.html
@@ -1,2 +1,2 @@
 <span ng-bind="$getDisplayText()"></span>
-<a class="remove-button" ng-click="$removeTag()" ng-bind="::$$removeTagSymbol"></a>
+<a class="remove-button" ng-click="$removeTag()" ng-bind="::$$removeTagSymbol" role="button" title="remove"></a>

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -19,7 +19,8 @@
            ng-trim="false"
            ng-class="{'invalid-tag': newTag.invalid}"
            ng-disabled="disabled"
-           ti-bind-attrs="{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex, spellcheck: options.spellcheck}"
+           aria-label="{{options.placeholder}}"
+           ti-bind-attrs="{ id:options.id +'-input', type: options.type,  placeholder: options.placeholder, tabindex: options.tabindex, spellcheck: options.spellcheck}"
            ti-autosize>
   </div>
 </div>


### PR DESCRIPTION
feat(tagsInput): A11y (accessibility) add aria-label and id attribute to tag <input >

Sets placeholder option to aria-label attribute, and adds a unique id to the input for better accessibility support.

This feature enhances screen reader experience of the input field to enter tags, allowing anyone to add a <label for="myTagInput-input"> that describes what is behind the input.  