### PR TITLE
allow to specify custom function for creating tag objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * **autocomplete:**
   * Stop preventing keys from being propagated ([b0db7633](https://github.com/mbenford/ngTagsInput/commit/b0db763301d483960cbb72bc0c3338a196eb8ef2), [#384](https://github.com/mbenford/ngTagsInput/issues/384))
   * Hide the suggestion list after a tag is removed ([731ef9eb](https://github.com/mbenford/ngTagsInput/commit/731ef9eb0874ae083cba47c942034cb9109e6cf9))
-  * Revert one-time binding in autocomplete list ([509b0509](https://github.com/mbenford/ngTagsInput/commit/509b05090d3999a07645201aac37e61c622507ca))
 * **tagsInput:**
   * Fix makeObjectArray function ([b5dc57f5](https://github.com/mbenford/ngTagsInput/commit/b5dc57f542c11351ad881e45cc238f75b9adc24a))
   * Remove model auto-initialization ([f9fcb12d](https://github.com/mbenford/ngTagsInput/commit/f9fcb12dc1c71a77e52ba573cd4505e663131625), [#320](https://github.com/mbenford/ngTagsInput/issues/320), [#204](https://github.com/mbenford/ngTagsInput/issues/204))
@@ -19,17 +18,8 @@
 
 #### Breaking Changes
 
-* Code that relies on auto-initialization of the model may
-stop working.
-
-Closes #320
-Closes #204
- ([f9fcb12d](https://github.com/mbenford/ngTagsInput/commit/f9fcb12dc1c71a77e52ba573cd4505e663131625))
-* This uses new API methods of Angular 1.3 and therefore
-the directive will no longer work with previous versions of the framework.
-
-Closes #318, #341, #373
- ([3355f3fa](https://github.com/mbenford/ngTagsInput/commit/3355f3fa7451dc0b4ca183875ba183a89c543be4))
+* Code that relies on auto-initialization of the model may stop working. ([f9fcb12d](https://github.com/mbenford/ngTagsInput/commit/f9fcb12dc1c71a77e52ba573cd4505e663131625))
+* This uses new API methods of Angular 1.3 and therefore the directive will no longer work with previous versions of the framework. ([3355f3fa](https://github.com/mbenford/ngTagsInput/commit/3355f3fa7451dc0b4ca183875ba183a89c543be4))
 
 ## 2.3.0 (2015-03-23)
 

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -46,9 +46,10 @@
  * @param {expression=} [onTagRemoved=NA] Expression to evaluate upon removing an existing tag. The removed tag is
  *    available as $tag.
  * @param {expression=} [onTagClicked=NA] Expression to evaluate upon clicking an existing tag. The clicked tag is available as $tag.
+ * @param {expression=} [createTagObject=NA] Expression to create a tag object on entering a new tag. The entered text is available as $text.
  */
 tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInputConfig, tiUtil) {
-    function TagList(options, events, onTagAdding, onTagRemoving) {
+    function TagList(options, events, onTagAdding, onTagRemoving, createTagObject) {
         var self = {}, getTagText, setTagText, tagIsValid;
 
         getTagText = function(tag) {
@@ -73,8 +74,11 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
         self.items = [];
 
         self.addText = function(text) {
-            var tag = {};
-            setTagText(tag, text);
+            var tag = createTagObject({ $text: text });
+            if (angular.isUndefined(tag)) {
+                tag = {};
+                setTagText(tag, text);
+            }
             return self.add(tag);
         };
 
@@ -158,7 +162,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
             onInvalidTag: '&',
             onTagRemoving: '&',
             onTagRemoved: '&',
-            onTagClicked: '&'
+            onTagClicked: '&',
+            createTagObject: '&'
         },
         replace: false,
         transclude: true,
@@ -194,7 +199,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
 
             $scope.tagList = new TagList($scope.options, $scope.events,
                 tiUtil.handleUndefinedResult($scope.onTagAdding, true),
-                tiUtil.handleUndefinedResult($scope.onTagRemoving, true));
+                tiUtil.handleUndefinedResult($scope.onTagRemoving, true),
+                $scope.createTagObject);
 
             this.registerAutocomplete = function() {
                 var input = $element.find('input');


### PR DESCRIPTION
When adding a new tag an empty object is created with just the display field being populated. This cannot work together with the key-property option as that will always be undefined. When we allow users to specify a function that creates the new tags for us, they can specify a unique key.

This fixes https://github.com/mbenford/ngTagsInput/issues/422