### PR TITLE
Added documentation entry for disabled attribute of tags-input.

### DIFF
--- a/_includes/api/tagsInput.html
+++ b/_includes/api/tagsInput.html
@@ -34,6 +34,7 @@
   [enable-editing-last-tag="{boolean}"]
   [add-from-autocomplete-only="{boolean}"]
   [spellcheck="{boolean}"]
+  [disabled="{boolean}"]
   [on-tag-adding="{expression}"]
   [on-tag-added="{expression}"]
   [on-invalid-tag="{expression}"]
@@ -205,6 +206,12 @@
           <td><span class="label type type-boolean">boolean</span></td>
           <td>Flag indicating whether the browser's spellcheck is enabled for the input field or not.</td>
           <td>true</td>
+        </tr>
+        <tr>
+          <td>disabled</td>
+          <td><span class="label type type-boolean">boolean</span></td>
+          <td>Flag indicating whether the control is disabled or not.</td>
+          <td>false</td>
         </tr>
         <tr>
           <td>onTagAdding</td>


### PR DESCRIPTION
This entry was missing from the docs which caused some confusion and forced us to come up with our own solutions for disabling the control until we've seen the changelog of 2.3.0.