### PR TITLE
cancel auto suggest loading that was reset during debounce period

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -56,6 +56,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
             self.index = -1;
             self.selected = null;
             self.query = null;
+            self.load.cancel();
         };
         self.show = function() {
             if (options.selectFirstMatch) {

--- a/src/util.js
+++ b/src/util.js
@@ -13,11 +13,15 @@ tagsInput.factory('tiUtil', function($timeout) {
 
     self.debounce = function(fn, delay) {
         var timeoutId;
-        return function() {
+        var debouncedFn = function() {
             var args = arguments;
             $timeout.cancel(timeoutId);
             timeoutId = $timeout(function() { fn.apply(null, args); }, delay);
         };
+        debouncedFn.cancel = function () {
+            $timeout.cancel(timeoutId);
+        };
+        return debouncedFn;
     };
 
     self.makeObjectArray = function(array, key) {


### PR DESCRIPTION
When a new tag is added (addText) during the autosuggest debounce period, it will still open the suggest list, because only pending loads are cancelled (checking if we have the latest promise at hand), not pending debounces.

This PR cancels pending debounces so the auto suggest list doesn't open although the tag has already been added.