### PR TITLE
Added option clearLeftoverTextOnBlur

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -188,6 +188,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 displayProperty: [String, 'text'],
                 keyProperty: [String, ''],
                 allowLeftoverText: [Boolean, false],
+                clearLeftoverTextOnBlur: [Boolean, false],
                 addFromAutocompleteOnly: [Boolean, false],
                 spellcheck: [Boolean, true]
             });
@@ -376,6 +377,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 .on('input-blur', function() {
                     if (options.addOnBlur && !options.addFromAutocompleteOnly) {
                         tagList.addText(scope.newTag.text());
+                    }
+                    else if (options.clearLeftoverTextOnBlur) {
+                        scope.newTag.text('');
                     }
                     element.triggerHandler('blur');
                     setElementValidity();

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1472,6 +1472,37 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('clear-leftover-text-on-blur option', function() {
+        it('clears the text in the input field when the input field loses focus if clearLeftoverTextOnBlur is true and addOnBlur is false', function() {
+            // Arrange
+            compile('clear-leftover-text-on-blur="true"', 'add-on-blur="false"', 'text="prop"');
+            $scope.prop = 'some text';
+            $scope.$digest();
+
+            // Act
+            isolateScope.events.trigger('input-blur');
+            $scope.$digest();
+
+            // Assert
+            expect(getInput().val()).toEqual('');
+            expect($scope.prop).toEqual('');
+        });
+
+        it('does not clear the text in the input field when the input field loses focus if clearLeftoverTextOnBlur is false and addOnBlur is false', function() {
+            // Arrange
+            compile('clear-leftover-text-on-blur="false"', 'add-on-blur="false"', 'text="prop"');
+            changeInputValue('some text');
+
+            // Act
+            isolateScope.events.trigger('input-blur');
+            $scope.$digest();
+
+            // Assert
+            expect(getInput().val()).toEqual('some text');
+            expect($scope.prop).toEqual('some text');
+        });
+    });
+
     describe('add-from-autocomplete-only option', function() {
         it('initializes the option to false', function() {
             // Arrange/Act


### PR DESCRIPTION
If the option "clearLeftoverTextOnBlur" is true then when losing focus any extra text will simply be removed, unless addOnBlur is true (and addFromAutocompleteOnly is false) in which case the extra text will be converted into a tag (as until now). 

Can be really useful for scenarios where you have lots of tagsinput directives throughout the app and you want all of them to have this behavior. Without this option the alternative is to actually set the value of the property bound to "text" to some empty string, but the disadvantage is you have to do it everywhere in the app. Another option would be a "companion" directive which does this, but I guess having it directly baked in could make more sense.