### PR TITLE
feat(tagsInput): Add disableRemoveConfirmation option

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -34,6 +34,7 @@
  * @param {string=} [allowedTagsPattern=.+] Regular expression that determines whether a new tag is valid.
  * @param {boolean=} [enableEditingLastTag=false] Flag indicating that the last tag will be moved back into the new tag
  *    input box instead of being removed when the backspace key is pressed and the input box is empty.
+ * @param {boolean=} [disableRemoveConfirmation=false] Flag indicating that the last tag will be immediately removed when the backspace key is pressed instead of highlighting it for removal which is the default. Ignored if enableEditingLastTag is true.
  * @param {boolean=} [addFromAutocompleteOnly=false] Flag indicating that only tags coming from the autocomplete list
  *    will be allowed. When this flag is true, addOnEnter, addOnComma, addOnSpace and addOnBlur values are ignored.
  * @param {boolean=} [spellcheck=true] Flag indicating whether the browser's spellcheck is enabled for the input field or not.
@@ -183,6 +184,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 pasteSplitPattern: [RegExp, /,/],
                 allowedTagsPattern: [RegExp, /.+/],
                 enableEditingLastTag: [Boolean, false],
+                disableRemoveConfirmation: [Boolean, false],
                 minTags: [Number, 0],
                 maxTags: [Number, MAX_SAFE_INTEGER],
                 displayProperty: [String, 'text'],
@@ -383,7 +385,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 .on('input-keydown', function(event) {
                     var key = event.keyCode,
                         addKeys = {},
-                        shouldAdd, shouldRemove, shouldSelect, shouldEditLastTag;
+                        shouldAdd, shouldRemoveHighlightedTag,
+                        shouldRemoveWithoutConfirmation, shouldRemove,
+                        shouldSelect, shouldEditLastTag;
 
                     if (tiUtil.isModifierOn(event) || hotkeys.indexOf(key) === -1) {
                         return;
@@ -394,7 +398,9 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                     addKeys[KEYS.space] = options.addOnSpace;
 
                     shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
-                    shouldRemove = (key === KEYS.backspace || key === KEYS.delete) && tagList.selected;
+                    shouldRemoveHighlightedTag = (key === KEYS.backspace || key === KEYS.delete) && tagList.selected;
+                    shouldRemoveWithoutConfirmation = key === KEYS.backspace && scope.newTag.text().length === 0 && !options.enableEditingLastTag && options.disableRemoveConfirmation;
+                    shouldRemove = shouldRemoveHighlightedTag || shouldRemoveWithoutConfirmation;
                     shouldEditLastTag = key === KEYS.backspace && scope.newTag.text().length === 0 && options.enableEditingLastTag;
                     shouldSelect = (key === KEYS.backspace || key === KEYS.left || key === KEYS.right) && scope.newTag.text().length === 0 && !options.enableEditingLastTag;
 

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -1127,6 +1127,139 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('disable-remove-confirmation option', function() {
+        beforeEach(function() {
+            $scope.tags = generateTags(3);
+        });
+
+        it('initializes the option to false', function() {
+            // Arrange/Act
+            compile();
+
+            // Assert
+            expect(isolateScope.options.disableRemoveConfirmation).toBe(false);
+        });
+
+        describe('option is on', function() {
+            beforeEach(function() {
+                compile('disable-remove-confirmation="true"');
+            });
+
+            describe('backspace is pressed once', function() {
+                it('removes the last tag when the input field is empty', function() {
+                    // Arrange
+                    spyOn(isolateScope.events, 'trigger').and.callThrough();
+                    // Act
+                    sendBackspace();
+
+                    // Assert
+                    expect(getInput().val()).toBe('');
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }]);
+                    expect(isolateScope.tagList.selected).toBe(null);
+                    expect(isolateScope.tagList.index).toBe(-1);
+                });
+
+                it('does nothing when the input field is not empty', function() {
+                    // Act
+                    sendKeyPress(65);
+                    sendBackspace();
+
+                    // Assert
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }, { text: 'Tag3' }]);
+                });
+            });
+        });
+
+        describe('option is on, but enable-editing-last-tag option is also on', function() {
+            beforeEach(function() {
+                compile('disable-remove-confirmation="true"', 'enable-editing-last-tag="true"');
+            });
+
+            describe('backspace is pressed once', function() {
+                it('moves the last tag back into the input field when the input field is empty', function() {
+                    // Arrange
+                    spyOn(isolateScope.events, 'trigger').and.callThrough();
+                    // Act
+                    sendBackspace();
+
+                    // Assert
+                    expect(getInput().val()).toBe('Tag3');
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }]);
+                    expect(isolateScope.events.trigger).toHaveBeenCalledWith('input-change', 'Tag3');
+                });
+
+                it('does nothing when the input field is not empty', function() {
+                    // Act
+                    sendKeyPress(65);
+                    sendBackspace();
+
+                    // Assert
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }, { text: 'Tag3' }]);
+                });
+            });
+        });
+
+        describe('option is off', function() {
+            beforeEach(function() {
+                compile('disable-remove-confirmation="false"');
+            });
+
+            describe('backspace is pressed once', function() {
+                it('highlights the tag about to be removed when the input box is empty', function() {
+                    // Act
+                    sendBackspace();
+
+                    // Assert
+                    expect(getTag(2)).toHaveClass('selected');
+                });
+
+                it('does nothing when the input field is not empty', function() {
+                    // Act
+                    sendKeyPress(65);
+                    sendBackspace();
+
+                    // Assert
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }, { text: 'Tag3' }]);
+                });
+
+                it('stops highlighting the last tag when the input box becomes non-empty', function() {
+                    // Act
+                    sendBackspace();
+                    sendKeyPress(65);
+
+                    // Assert
+                    expect(getTag(2)).not.toHaveClass('selected');
+                    expect(isolateScope.tagList.selected).toBe(null);
+                    expect(isolateScope.tagList.index).toBe(-1);
+                });
+            });
+
+            describe('backspace is pressed twice', function() {
+                it('removes the last tag when the input field is empty', function() {
+                    // Act
+                    sendBackspace();
+                    sendBackspace();
+
+                    // Assert
+                    expect(getInput().val()).toBe('');
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }]);
+                    expect(isolateScope.tagList.selected).toBe(null);
+                    expect(isolateScope.tagList.index).toBe(-1);
+                });
+
+                it('does nothing when the input field is not empty', function() {
+                    // Act
+                    sendKeyPress(65);
+                    sendBackspace();
+                    sendBackspace();
+
+                    // Assert
+                    expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag2' }, { text: 'Tag3' }]);
+                });
+            });
+        });
+    });
+
     describe('min-tags option', function() {
         it('initializes the option to 0', function() {
             // Arrange/Act


### PR DESCRIPTION
Add disableRemoveConfirmation option so that you can press backspace once to remove the last tag instead of having to press it twice.

Closes #130 

Tried to cover everything mentioned in CONTRIBUTING.md. Let me know if I missed anything.