### PR TITLE
feat(tagsInput): Add addOnSemicolon option

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,8 @@ var KEYS = {
     left: 37,
     right: 39,
     delete: 46,
-    comma: 188
+    comma: 188,
+    semicolon: 186
 };
 
 var MAX_SAFE_INTEGER = 9007199254740991;

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -27,6 +27,7 @@
  * @param {boolean=} [addOnEnter=true] Flag indicating that a new tag will be added on pressing the ENTER key.
  * @param {boolean=} [addOnSpace=false] Flag indicating that a new tag will be added on pressing the SPACE key.
  * @param {boolean=} [addOnComma=true] Flag indicating that a new tag will be added on pressing the COMMA key.
+ * @param {boolean=} [addOnSemicolon=false] Flag indicating that a new tag will be added on pressing the SEMICOLON key.
  * @param {boolean=} [addOnBlur=true] Flag indicating that a new tag will be added when the input field loses focus.
  * @param {boolean=} [addOnPaste=false] Flag indicating that the text pasted into the input field will be split into tags.
  * @param {string=} [pasteSplitPattern=,] Regular expression used to split the pasted text into tags.
@@ -178,6 +179,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                 addOnEnter: [Boolean, true],
                 addOnSpace: [Boolean, false],
                 addOnComma: [Boolean, true],
+                addOnSemicolon: [Boolean, false],
                 addOnBlur: [Boolean, true],
                 addOnPaste: [Boolean, false],
                 pasteSplitPattern: [RegExp, /,/],
@@ -237,7 +239,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
             };
         },
         link: function(scope, element, attrs, ngModelCtrl) {
-            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace, KEYS.delete, KEYS.left, KEYS.right],
+            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.semicolon, KEYS.backspace, KEYS.delete, KEYS.left, KEYS.right],
                 tagList = scope.tagList,
                 events = scope.events,
                 options = scope.options,
@@ -392,6 +394,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, tagsInpu
                     addKeys[KEYS.enter] = options.addOnEnter;
                     addKeys[KEYS.comma] = options.addOnComma;
                     addKeys[KEYS.space] = options.addOnSpace;
+                    addKeys[KEYS.semicolon] = options.addOnSemicolon;
 
                     shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
                     shouldRemove = (key === KEYS.backspace || key === KEYS.delete) && tagList.selected;

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -581,6 +581,38 @@ describe('tags-input directive', function() {
         });
     });
 
+    describe('add-on-semicolon option', function () {
+        it('add a new tag when the semicolon is pressed and the option is true', function () {
+            //Arrange
+            compile('add-on-semicolon="true"');
+
+            //Act
+            newTag('foo', KEYS.semicolon);
+
+            //Assert
+            expect($scope.tags).toEqual([{ text: 'foo'}]);
+        });
+
+        it('does not add a new tag when the semicolon key is pressed and the option is false', function () {
+            //Arrange
+            compile('add-on-semicolon="false"');
+
+            //Act
+            newTag('foo', KEYS.semicolon);
+
+            //Assert
+            expect($scope.tags).toBeUndefined();
+        });
+
+        it('initialize the option to false', function () {
+            //Arrange/Act
+            compile();
+
+            //Assert
+            expect(isolateScope.options.addOnSemicolon).toBe(false);
+        });
+    });
+
     describe('add-on-blur option', function() {
         it('initializes the option to true', function() {
             // Arrange/Act
@@ -1484,7 +1516,7 @@ describe('tags-input directive', function() {
         describe('option is true', function() {
             beforeEach(function() {
                 compileWithForm('add-from-autocomplete-only="true"', 'name="tags"', 'allow-leftover-text="false"',
-                    'add-on-blur="true"', 'add-on-enter="true"', 'add-on-comma="true"', 'add-on-space="true"');
+                    'add-on-blur="true"', 'add-on-enter="true"', 'add-on-comma="true"', 'add-on-space="true"', 'add-on-semicolon="true"');
             });
 
             it('does not add a tag when the enter key is pressed', function() {
@@ -1508,6 +1540,15 @@ describe('tags-input directive', function() {
                 newTag('foo', KEYS.space);
 
                 // Assert
+                expect($scope.tags).toBeUndefined();
+            });
+
+
+            it('does not add a tag when the semicolon is pressed', function() {
+                //Act
+                newTag('foo', KEYS.semicolon);
+
+                //Assert
                 expect($scope.tags).toBeUndefined();
             });
 
@@ -2003,10 +2044,10 @@ describe('tags-input directive', function() {
     });
 
     describe('hotkeys propagation handling', function() {
-        var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace];
+        var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.semicolon, KEYS.backspace];
 
         beforeEach(function() {
-            compile('add-on-enter="true"', 'add-on-space="true"', 'add-on-comma="true"');
+            compile('add-on-enter="true"', 'add-on-space="true"', 'add-on-comma="true"', 'add-on-semicolon="true"');
         });
 
         describe('modifier key is on', function() {
@@ -2032,7 +2073,7 @@ describe('tags-input directive', function() {
         describe('modifier key is off', function() {
             it('prevents enter, comma and space keys from being propagated when all modifiers are up', function() {
                 // Arrange
-                hotkeys = [KEYS.enter, KEYS.comma, KEYS.space];
+                hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.semicolon];
 
                 // Act/Assert
                 angular.forEach(hotkeys, function(key) {


### PR DESCRIPTION
Add an option for the user to set if a tag should be created when
semicolon is pressed. This feature is important because works like
multiple email input as tag input.