### PR TITLE
Fixed for issue: Cannot read property 'data' of undefined #570

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -73,7 +73,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
             lastPromise = promise;
 
             promise.then(function(items) {
-                if (promise !== lastPromise) {
+                if (promise !== lastPromise || !items) {
                     return;
                 }
 


### PR DESCRIPTION
Sometime the auto complete throw an error message to the console like this:
TypeError: Cannot read property 'data' of undefined
    at ng-tags-input.js:590
    at angular.js:14567
    at n.$eval (angular.js:15846)
    at n.$digest (angular.js:15657)
    at n.$apply (angular.js:15951)
    at angular.js:17718
    at e (angular.js:5394)
    at angular.js:5666

And this line will fixed for that error message.