### PR TITLE
Return Original Object From SuggestionList

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -186,7 +186,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 var added = false;
 
                 if (suggestionList.selected) {
-                    tagsInput.addTag(angular.copy(suggestionList.selected));
+                    tagsInput.addTag(suggestionList.selected);
                     suggestionList.reset();
                     added = true;
                 }


### PR DESCRIPTION
I needed the original object back from the suggestion list. If the developer wants a copy of the tag to be placed inside the array, he or she should be able to specify that during "Adding" with the onTagAdding method.

function($tag){
return angular.copy($tag);
}