### PR TITLE
feat(tagsInput): Add track-by-expr option

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -48,10 +48,14 @@ tagsInput.factory('tiUtil', function($timeout, $q) {
         return item;
     };
 
-    self.defaultComparer = function(a, b) {
+    self.normalizeString = function(str) {
         // I'm aware of the internationalization issues regarding toLowerCase()
         // but I couldn't come up with a better solution right now
-        return self.safeToString(a).toLowerCase() === self.safeToString(b).toLowerCase();
+        return self.safeToString(str).toLowerCase();
+    };
+
+    self.defaultComparer = function(a, b) {
+        return self.normalizeString(a) === self.normalizeString(b);
     };
 
     self.safeHighlight = function(str, value) {

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -2,7 +2,7 @@
   <div class="tags" ng-class="{focused: hasFocus}">
     <ul class="tag-list">
       <li class="tag-item"
-          ng-repeat="tag in tagList.items track by track(tag)"
+          ng-repeat="tag in tagList.items track by track(tag, $index)"
           ng-class="{ selected: tag == tagList.selected }"
           ng-click="eventHandlers.tag.click(tag)">
         <ti-tag-item data="::tag"></ti-tag-item>

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -136,21 +136,19 @@ describe('tags-input directive', function() {
                 { text: true },
                 { text: 1.5 },
                 { text: {} },
-                { text: null },
-                { text: undefined }
+                { text: null }
             ];
 
             // Act
             compile();
 
             // Assert
-            expect(getTags().length).toBe(6);
+            expect(getTags().length).toBe(5);
             expect(getTagText(0)).toBe('1');
             expect(getTagText(1)).toBe('true');
             expect(getTagText(2)).toBe('1.5');
             expect(getTagText(3)).toBe('[object Object]');
             expect(getTagText(4)).toBe('');
-            expect(getTagText(5)).toBe('');
         });
 
         it('updates the model', function() {
@@ -1379,6 +1377,54 @@ describe('tags-input directive', function() {
 
             // Act
             isolateScope.tagList.add({ id: 1, text: 'Other' });
+
+            // Assert
+            expect($scope.tags).toEqual([{ id: 1, text: 'Tag' }]);
+        });
+    });
+
+    describe('track-by-expr option', function () {
+        it('allows using an expression to be evaluated as unique identifier', function () {
+            // Arrange
+            $scope.track = function ($tag, $index) { return $tag.id || $index; };
+            $scope.tags = [
+                { id: 'a', text: 'Tag' },
+                { text: 'Tag' },
+                { text: 'Tag' }
+            ];
+
+            // Act
+            compile('track-by-expr="track($tag, $index)"');
+
+            // Assert
+            expect(getTagText(0)).toBe('Tag');
+            expect(getTagText(1)).toBe('Tag');
+            expect(getTagText(2)).toBe('Tag');
+        });
+
+        it('fails to render tags with duplicate identifiers', function () {
+            // Arrange
+            $scope.track = function () { return 1; };
+            $scope.tags = [
+                { text: 'Tag' },
+                { text: 'Other' }
+            ];
+
+            // Act/Assert
+            expect(function() { compile('track-by-expr="track($tag, $index)"'); }).toThrowError();
+        });
+
+        it('doesn\'t allow tags with duplicate keys', function () {
+            // Arrange
+            $scope.track = function ($tag) { return $tag.id; };
+            $scope.tags = [
+                { id: 1, text: 'Tag' }
+            ];
+            compile('track-by-expr="track($tag, $index)"');
+
+            // Act
+            isolateScope.tagList.add({ id: 1, text: 'Other' });
+            $scope.$digest();
 
             // Assert
             expect($scope.tags).toEqual([{ id: 1, text: 'Tag' }]);


### PR DESCRIPTION
I've added a `track-by-expr` option that allows using a custom expression for tracking tags. This way you can do whatever you want to handle the ng-repeat's track by.

I've also made a few changes to the canAdd and track functions so they are more consistent. Until now, canAdd would consider `foo` and `Foo` to be the same value while the track by wouldn't. It was also possible to introduce duplicate values with invalid text such as `null` and `undefined`.