### PR TITLE
feat(autocomplete): Add addOnTab option

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -27,6 +27,8 @@
  *    gains focus. The current input value is available as $query.
  * @param {boolean=} [selectFirstMatch=true] Flag indicating that the first match will be automatically selected once
  *    the suggestion list is shown.
+ * @param {boolean=} [addOnTab=true] Flag indicating that the selected match will be automatically selected once
+ *    the tab key is pressed.
  */
 tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil) {
     function SuggestionList(loadFn, options, events) {
@@ -147,7 +149,8 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 loadOnEmpty: [Boolean, false],
                 loadOnFocus: [Boolean, false],
                 selectFirstMatch: [Boolean, true],
-                displayProperty: [String, '']
+                displayProperty: [String, ''],
+                addOnTab: [Boolean, true]
             });
 
             $scope.suggestionList = new SuggestionList($scope.source, $scope.options, $scope.events);
@@ -237,7 +240,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                             suggestionList.reset();
                             handled = true;
                         }
-                        else if (key === KEYS.enter || key === KEYS.tab) {
+                        else if (key === KEYS.enter || (scope.options.addOnTab && key === KEYS.tab)) {
                             handled = scope.addSuggestion();
                         }
                     }

--- a/test/auto-complete.spec.js
+++ b/test/auto-complete.spec.js
@@ -344,6 +344,19 @@ describe('autoComplete directive', function() {
             expect(tagsInput.addTag).toHaveBeenCalledWith({ text: 'Item1' });
         });
 
+        it('does not add the selected suggestion when the tab key is pressed and the suggestions box is visible and addOnTab is false', function() {
+            // Arrange
+            compile('add-on-tab="false"');
+            loadSuggestions(2);
+            suggestionList.select(0);
+
+            // Act
+            sendKeyDown(KEYS.tab);
+
+            // Assert
+            expect(tagsInput.addTag).not.toHaveBeenCalled();
+        });
+
         it('adds the selected suggestion when the tab key is pressed and there is a suggestion selected', function() {
             // Arrange
             loadSuggestions(2);


### PR DESCRIPTION
Add an option for the user to set if a tag should be created when tab is pressed.
This feature is important because it allows users to move between input fields
without using the mouse.