### PR TITLE
Make ng-tags work with jquery 1.8

### DIFF
--- a/src/bind-attrs.js
+++ b/src/bind-attrs.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global console*/
 
 /**
  * @ngdoc directive
@@ -12,7 +13,15 @@ tagsInput.directive('tiBindAttrs', function() {
     return function(scope, element, attrs) {
         scope.$watch(attrs.tiBindAttrs, function(value) {
             angular.forEach(value, function(value, key) {
-                attrs.$set(key, value);
+                try {
+                    attrs.$set(key, value);
+                } catch (error) {
+                    // workaround for jQuery 1.8 (https://bugs.jquery.com/ticket/13011)
+                    // see https://github.com/mbenford/ngTagsInput/issues/405
+                    if (console && console.error) {
+                        console.error('Error while setting ' + key + ' to ' + value + ': ' + error.message);
+                    }
+                }
             });
         }, true);
     };


### PR DESCRIPTION
Workaround for https://github.com/mbenford/ngTagsInput/issues/405

In the project I am currently working on I cannot upgrade jQuery right now. This workaround makes ng-tags work with jQuery 1.8 (changing input type to something other than 'text' does not work)