### PR TITLE
Array of strings

### DIFF
--- a/src/auto-complete-match.js
+++ b/src/auto-complete-match.js
@@ -31,10 +31,10 @@ tagsInput.directive('tiAutocompleteMatch', function($sce, tiUtil) {
                 return $sce.trustAsHtml(text);
             };
             scope.$getDisplayText =  function() {
-                if (options.tagsInput.itemIsObject){
-                    return tiUtil.safeToString(scope.data[options.displayProperty || options.tagsInput.displayProperty]);
+                if (options.tagsInput.itemIsObject || !options.tagsInput.itemIsObject) {
+                  return tiUtil.safeToString(scope.data[options.displayProperty || options.tagsInput.displayProperty]);
                 } else {
-                    return tiUtil.safeToString(scope.data);
+                  return tiUtil.safeToString(scope.data);
                 }
             };
         }

--- a/src/auto-complete-match.js
+++ b/src/auto-complete-match.js
@@ -31,7 +31,11 @@ tagsInput.directive('tiAutocompleteMatch', function($sce, tiUtil) {
                 return $sce.trustAsHtml(text);
             };
             scope.$getDisplayText =  function() {
-                return tiUtil.safeToString(scope.data[options.displayProperty || options.tagsInput.displayProperty]);
+                if (options.tagsInput.itemIsObject){
+                    return tiUtil.safeToString(scope.data[options.displayProperty || options.tagsInput.displayProperty]);
+                } else {
+                    return tiUtil.safeToString(scope.data);
+                }
             };
         }
     };

--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -37,7 +37,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
         var self = {}, getDifference, lastPromise, getTagId;
 
         getTagId = function() {
-            if (options.tagsInput.itemIsObject) {
+            if (options.tagsInput.itemIsObject || !options.tagsInput.itemIsObject) {
                 return options.tagsInput.keyProperty || options.tagsInput.displayProperty;
             } else {
                 return null;
@@ -46,7 +46,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
 
         getDifference = function(array1, array2) {
             return array1.filter(function(item) {
-                if (options.tagsInput.itemIsObject) {
+                if (options.tagsInput.itemIsObject || !options.tagsInput.itemIsObject) {
                     return !tiUtil.findInObjectArray(array2, item, getTagId(), function(a, b) {
                         if (options.tagsInput.replaceSpacesWithDashes) {
                             a = tiUtil.replaceSpacesWithDashes(a);
@@ -95,7 +95,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                     return;
                 }
 
-                if (options.tagsInput.itemIsObject){
+                if (options.tagsInput.itemIsObject || !options.tagsInput.itemIsObject){
                     items = tiUtil.makeObjectArray(items.data || items, getTagId());
                 }
 
@@ -220,7 +220,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
             };
 
             scope.track = function(item) {
-                if (options.tagsInput.itemIsObject) {
+                if (options.tagsInput.itemIsObject || !options.tagsInput.itemIsObject) {
                     return item[options.tagsInput.keyProperty || options.tagsInput.displayProperty];
                 } else {
                     return item;

--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -37,18 +37,32 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
         var self = {}, getDifference, lastPromise, getTagId;
 
         getTagId = function() {
-            return options.tagsInput.keyProperty || options.tagsInput.displayProperty;
+            if (options.tagsInput.itemIsObject) {
+                return options.tagsInput.keyProperty || options.tagsInput.displayProperty;
+            } else {
+                return null;
+            }
         };
 
         getDifference = function(array1, array2) {
             return array1.filter(function(item) {
-                return !tiUtil.findInObjectArray(array2, item, getTagId(), function(a, b) {
-                    if (options.tagsInput.replaceSpacesWithDashes) {
-                        a = tiUtil.replaceSpacesWithDashes(a);
-                        b = tiUtil.replaceSpacesWithDashes(b);
-                    }
-                    return tiUtil.defaultComparer(a, b);
-                });
+                if (options.tagsInput.itemIsObject) {
+                    return !tiUtil.findInObjectArray(array2, item, getTagId(), function(a, b) {
+                        if (options.tagsInput.replaceSpacesWithDashes) {
+                            a = tiUtil.replaceSpacesWithDashes(a);
+                            b = tiUtil.replaceSpacesWithDashes(b);
+                        }
+                        return tiUtil.defaultComparer(a, b);
+                    });
+                } else {
+                    return !tiUtil.findInStringArray(array2, item, function(a, b) {
+                        if (options.tagsInput.replaceSpacesWithDashes) {
+                            a = tiUtil.replaceSpacesWithDashes(a);
+                            b = tiUtil.replaceSpacesWithDashes(b);
+                        }
+                        return tiUtil.defaultComparer(a, b);
+                    });
+                }
             });
         };
 
@@ -81,7 +95,10 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                     return;
                 }
 
-                items = tiUtil.makeObjectArray(items.data || items, getTagId());
+                if (options.tagsInput.itemIsObject){
+                    items = tiUtil.makeObjectArray(items.data || items, getTagId());
+                }
+
                 items = getDifference(items, tags);
                 self.items = items.slice(0, options.maxResultsToShow);
 
@@ -203,7 +220,11 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
             };
 
             scope.track = function(item) {
-                return item[options.tagsInput.keyProperty || options.tagsInput.displayProperty];
+                if (options.tagsInput.itemIsObject) {
+                    return item[options.tagsInput.keyProperty || options.tagsInput.displayProperty];
+                } else {
+                    return item;
+                }
             };
 
             scope.getSuggestionClass = function(item, index) {

--- a/src/tag-item.js
+++ b/src/tag-item.js
@@ -25,7 +25,11 @@ tagsInput.directive('tiTagItem', function(tiUtil) {
             scope.$$removeTagSymbol = options.removeTagSymbol;
 
             scope.$getDisplayText = function() {
-                return tiUtil.safeToString(scope.data[options.displayProperty]);
+                if (options.itemIsObject){
+                    return tiUtil.safeToString(scope.data[options.displayProperty]);
+                } else {
+                    return tiUtil.safeToString(scope.data);
+                }
             };
             scope.$removeTag = function() {
                 tagsInput.removeTag(scope.$index);

--- a/src/util.js
+++ b/src/util.js
@@ -48,6 +48,20 @@ tagsInput.factory('tiUtil', function($timeout, $q) {
         return item;
     };
 
+    self.findInStringArray = function(array, str, comparer) {
+        var item = null;
+        comparer = comparer || self.defaultComparer;
+
+        array.some(function(element) {
+            if (comparer(element, str)) {
+                item = element;
+                return true;
+            }
+        });
+
+        return item;
+    };
+
     self.defaultComparer = function(a, b) {
         // I'm aware of the internationalization issues regarding toLowerCase()
         // but I couldn't come up with a better solution right now


### PR DESCRIPTION
Hi, I worked on a feature that is very much requested.

Turning on **itemIsObject** (off by default for backwards compatibility) will create an array of strings instead of objects. I'm using it on production without problems.