### PR TITLE
fix(tagsInput): Disable error shadow for pristine control

### DIFF
--- a/scss/tags-input.scss
+++ b/scss/tags-input.scss
@@ -78,7 +78,7 @@ tags-input {
 
   }
 
-  &.ng-invalid .tags {
+  &.ng-invalid.ng-dirty .tags {
     @include box-shadow($tags-outline-box-shadow-invalid);
   }
 


### PR DESCRIPTION
Standard behavior for required directive is to keep control invalid but hide error message

Closes #641.