### PR TITLE
feat(tagsInput): Allow double click to edit and split tag

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -6,6 +6,7 @@ import AutocompleteDirective from './auto-complete';
 import AutocompleteMatchDirective from './auto-complete-match';
 import AutosizeDirective from './autosize';
 import BindAttributesDirective from './bind-attrs';
+import SelectallDirective from './selectall';
 import TranscludeAppendDirective from './transclude-append';
 import TagsInputConfigurationProvider from './configuration';
 import UtilService from './util';
@@ -19,6 +20,7 @@ angular.module('ngTagsInput', [])
     .directive('tiAutosize', AutosizeDirective)
     .directive('tiBindAttrs', BindAttributesDirective)
     .directive('tiTranscludeAppend', TranscludeAppendDirective)
+    .directive('tiSelectall', SelectallDirective)
     .factory('tiUtil', UtilService)
     .constant('tiConstants', Constants)
     .provider('tagsInputConfig', TagsInputConfigurationProvider)

--- a/src/selectall.js
+++ b/src/selectall.js
@@ -1,0 +1,31 @@
+/**
+ * @ngdoc directive
+ * @name tiSelectall
+ * @module ngTagsInput
+ *
+ * @description
+ * Automatically select all and focus the input. Used internally by tagsInput directive.
+ */
+
+export default function SelectallDirective($timeout, $parse) {
+  'ngInject';
+  return {
+    scope: {},
+    link(scope, element, attrs) {
+      scope.selectAll = false;
+      let model = $parse(attrs.tiSelectall);
+      let selectAll = () => {
+        $timeout(() => {
+          element[0].focus();
+          element[0].select();
+        });
+      };
+      scope.$watch(model, (value) =>{
+        if (value === true) {
+          selectAll();
+        }
+        scope.selectAll = value;
+      });
+    }
+  };
+}

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -1,11 +1,24 @@
 <div class="host" tabindex="-1" ng-click="eventHandlers.host.click()" ti-transclude-append>
   <div class="tags" ng-class="{focused: hasFocus}">
     <ul class="tag-list">
-      <li class="tag-item"
-          ng-repeat="tag in tagList.items track by track(tag)"
+      <li ng-repeat="tag in tagList.items track by track(tag)"
           ng-class="getTagClass(tag, $index)"
-          ng-click="eventHandlers.tag.click(tag)">
-        <ti-tag-item scope="templateScope" data="::tag"></ti-tag-item>
+          ng-click="eventHandlers.tag.click(tag)"
+          ng-dblclick="eventHandlers.tag.dblclick(tag)">
+        <ti-tag-item class="tag-item" scope="templateScope" data="tag" ng-hide="tag.editable"></ti-tag-item>
+        <input class="input"
+               autocomplete="off"
+               ng-model="editingTag.text"
+               ng-model-options="{getterSetter: true}"
+               ng-click="$event.stopPropagation();"
+               ng-if="tag.editable"
+               ng-keydown="eventHandlers.input.keydown($event)"
+               ng-blur="eventHandlers.input.editBlur($event,tag)"
+               ng-paste="eventHandlers.input.paste($event)"
+               ng-disabled="disabled"
+               ng-class="{'invalid-tag': editingTag.invalid}"
+               ti-selectall='true'
+               ti-autosize="">
       </li>
     </ul>
     <input class="input"

--- a/test/selectall.spec.js
+++ b/test/selectall.spec.js
@@ -1,0 +1,44 @@
+'use strict';
+
+describe('selectall directive', () => {
+  var $scope, $compile, element, $timeout, isolateScope;
+  beforeEach(() => {
+    module('ngTagsInput');
+
+    inject(($rootScope, _$compile_, _$timeout_) => {
+      $scope = $scope = $rootScope.$new();
+      $compile = _$compile_;
+      $timeout = _$timeout_;
+    });
+
+  });
+
+  function compile() {
+    let attributes = $.makeArray(arguments).join(' ');
+
+    element = angular.element('<input class="input" ng-model="model" ' + attributes + '>');
+    $compile(element)($scope);
+    isolateScope = element.isolateScope();
+    $scope.$digest();
+  }
+
+  it('input select all and focus', () => {
+    // Act/Arrange
+    compile('ti-selectall="true"');
+    $timeout.flush();
+
+    //Assert
+    expect(isolateScope.selectAll).toBe(true);
+  });
+
+  it('input not select all and focus', () => {
+    // Act/Arrange
+    compile('ti-selectall="false"');
+    $timeout.flush();
+
+    //Assert
+    expect(isolateScope.selectAll).toBe(false);
+  });
+
+
+});


### PR DESCRIPTION
Add `allowDblclickToEdit` `inputSplitPattern` options so that you can use double click to edit current tag and split tag by pattern

We can try [here](https://plnkr.co/edit/9wbMHu?p=preview)

[#282](https://github.com/mbenford/ngTagsInput/issues/282) #674 