### PR TITLE
use $watchCollection to watch tags changed.

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -286,7 +286,7 @@ export default function TagsInputDirective($timeout, $document, $window, $q, tag
         ];
       };
 
-      scope.$watch('tags', value => {
+      scope.$watchCollection('tags', value => {
         if (value) {
           tagList.items = tiUtil.makeObjectArray(value, options.displayProperty);
           if (options.useStrings) {


### PR DESCRIPTION
now support auto refresh tags after changing ng-model variable programatically. resolve #621 