### PR TITLE
fix(tagsInput): Fixes the "jumping focus" when tab key is hit

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -243,7 +243,7 @@ export default function TagsInputDirective($timeout, $document, $window, $q, tag
       });
     },
     link(scope, element, attrs, ngModelCtrl) {
-      let hotkeys = [tiConstants.KEYS.enter, tiConstants.KEYS.comma, tiConstants.KEYS.space, tiConstants.KEYS.backspace,
+      let hotkeys = [tiConstants.KEYS.enter, tiConstants.KEYS.tab, tiConstants.KEYS.comma, tiConstants.KEYS.space, tiConstants.KEYS.backspace,
         tiConstants.KEYS.delete, tiConstants.KEYS.left, tiConstants.KEYS.right];
       let tagList = scope.tagList;
       let events = scope.events;
@@ -411,6 +411,10 @@ export default function TagsInputDirective($timeout, $document, $window, $q, tag
             [tiConstants.KEYS.comma]: options.addOnComma,
             [tiConstants.KEYS.space]: options.addOnSpace
           };
+
+          if (key === tiConstants.KEYS.tab && scope.newTag.text().length > 0) {
+            addKeys[tiConstants.KEYS.tab] = options.addOnBlur;
+          }
 
           let shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
           let shouldRemove = (key === tiConstants.KEYS.backspace || key === tiConstants.KEYS.delete) && tagList.selected;

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -643,6 +643,17 @@ describe('tags-input directive', () => {
         // Assert
         expect($scope.tags).toBeUndefined();
       });
+
+      it('adds a new tag when the tab key is pressed and the input has text', () => {
+        // Arrange
+        isolateScope.newTag.text('foo');
+  
+        // Act
+        newTag('foo', constants.KEYS.tab);
+        
+        // Assert
+        expect($scope.tags).toEqual([{ text: 'foo' }]);
+      });
     });
 
     describe('option is off', () => {


### PR DESCRIPTION
When the tab key is hit (in order to add the tag to the list), the
"jumping focus" problem will no longer occur.

Closes #820.