### PR TITLE
Remove duplicate tags on paste

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -448,7 +448,12 @@ export default function TagsInputDirective($timeout, $document, $window, $q, tag
         .on('input-paste', event => {
           if (options.addOnPaste) {
             let data = event.getTextData();
-            let tags = data.split(options.pasteSplitPattern);
+
+            let tags = data
+              .split(options.pasteSplitPattern)
+              .filter((element, index, array) =>
+                  array.indexOf(element, index + 1) === -1
+              );
 
             if (tags.length > 1) {
               tags.forEach(tag => {

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -723,6 +723,24 @@ describe('tags-input directive', () => {
           expect(eventData.preventDefault).toHaveBeenCalled();
         });
 
+        it('removes duplicate tags from split text (' + name + ')', () => {
+          // Arrange
+          compile('add-on-paste="true"');
+          setup('tag1, tag2, tag2, tag3');
+
+          // Act
+          let event = jQuery.Event('paste', eventData);
+          getInput().trigger(event);
+
+          // Assert
+          expect($scope.tags).toEqual([
+            { text: 'tag1' },
+            { text: 'tag2' },
+            { text: 'tag3' }
+          ]);
+          expect(eventData.preventDefault).toHaveBeenCalled();
+        });
+
         it('doesn\'t split the pasted text into tags if there is just one tag (' + name + ')', () => {
           // Arrange
           compile('add-on-paste="true"');


### PR DESCRIPTION
I recently ran into this and saw issue #795. It's a decent workaround, but a more permanent fix might be helpful. 

It looks like when adding all of the tags from the paste, since everything is running async, the tags aren't present in the items array at the time of the duplicate check. We can get in front of this issue by removing duplicates from the split text before we try to insert duplicate values and have to check later down the road.